### PR TITLE
Add daily upstream develop sync and PR automation

### DIFF
--- a/.github/workflows/sync-upstream-develop.yml
+++ b/.github/workflows/sync-upstream-develop.yml
@@ -1,0 +1,77 @@
+name: sync-upstream-develop
+
+permissions: # Principle of least privilege
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # At 01:00 UTC daily
+  workflow_dispatch:
+
+concurrency:
+  group: sync-upstream-develop
+  cancel-in-progress: false
+
+jobs:
+  sync-and-open-pr:
+    runs-on: ubuntu-latest
+    env:
+      UPSTREAM_REPOSITORY: nautechsystems/nautilus_trader
+      DEVELOP_BRANCH: develop
+      MAIN_BRANCH: main
+    steps:
+      - name: Checkout repository
+        # https://github.com/actions/checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Configure Git user
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync develop from upstream
+        run: |
+          set -euo pipefail
+
+          if git remote get-url upstream >/dev/null 2>&1; then
+            git remote set-url upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          else
+            git remote add upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          fi
+
+          git fetch upstream "${DEVELOP_BRANCH}"
+          git fetch origin "${DEVELOP_BRANCH}"
+          git checkout "${DEVELOP_BRANCH}"
+
+          current_sha="$(git rev-parse HEAD)"
+          git merge --no-edit "upstream/${DEVELOP_BRANCH}"
+          updated_sha="$(git rev-parse HEAD)"
+
+          if [ "${current_sha}" != "${updated_sha}" ]; then
+            git push origin "${DEVELOP_BRANCH}"
+          fi
+
+      - name: Create or reuse PR from develop to main
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          existing_pr="$(gh pr list \
+            --base "${MAIN_BRANCH}" \
+            --head "${DEVELOP_BRANCH}" \
+            --state open \
+            --json number \
+            --jq '.[0].number')"
+
+          if [ -z "${existing_pr}" ]; then
+            gh pr create \
+              --base "${MAIN_BRANCH}" \
+              --head "${DEVELOP_BRANCH}" \
+              --title "Sync ${DEVELOP_BRANCH} into ${MAIN_BRANCH}" \
+              --body "Automated daily sync PR from upstream ${DEVELOP_BRANCH} into ${MAIN_BRANCH}."
+          fi


### PR DESCRIPTION
# Pull Request

**NautilusTrader prioritizes correctness and reliability, please follow existing patterns for validation and testing.**

- [ ] I have reviewed the `CONTRIBUTING.md` and followed the established practices

## Summary

This adds a scheduled GitHub Actions workflow to keep the fork's `develop` branch synchronized with `nautechsystems/nautilus_trader:develop` on a daily cadence. After syncing, it ensures there is an open PR from `develop` into `main`, reusing the same branch so the PR is continuously updated until manually merged.

## Related Issues/PRs

N/A

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature (non-breaking)
- [ ] Improvement (non-breaking)
- [ ] Breaking change (impacts existing behavior)
- [ ] Documentation update
- [x] Maintenance / chore

## Breaking change details (if applicable)

N/A

## Documentation

- [ ] Documentation changes follow the style guide (`docs/developer_guide/docs.md`)

## Release notes

- [ ] I added a concise entry to `RELEASES.md` that follows the existing conventions (when applicable)

## Testing

**Ensure new or changed logic is covered by tests.**

- [ ] Affected code paths are already covered by the test suite
- [ ] I added/updated tests to cover new or changed logic

Workflow YAML was validated for syntax, and the implementation follows existing repository workflow conventions. This change only adds CI automation and does not modify application runtime logic.