### PR TITLE
Codex/openalgo brokerage

### DIFF
--- a/.codex/skills/fork-pr-policy/SKILL.md
+++ b/.codex/skills/fork-pr-policy/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: fork-pr-policy
+description: Enforce this workspace's Git branch and pull-request policy. Use whenever Codex creates or rebases a branch, pushes changes, opens or updates a pull request, selects a base branch or repository, or considers merging work in the nautilus_trader workspace.
+---
+
+# Apply The Repository Policy
+
+Treat `arif-b-khan/nautilus_trader` as the writable repository and `main` as the base branch.
+
+## Branches
+
+- Create new work branches from the latest `origin/main`.
+- Use the `codex/` prefix unless the user specifies another branch name.
+- Do not base work on `develop` or an upstream branch.
+- Before creating or rebasing a branch, verify that `origin` resolves to `arif-b-khan/nautilus_trader` and fetch `origin main`.
+- Permit fetching from `upstream` only for read-only comparison or synchronization requested by the user. Never push to `upstream`.
+
+## Pull Requests
+
+- Set the pull request head to a branch in `arif-b-khan/nautilus_trader`.
+- Set the pull request base repository to `arif-b-khan/nautilus_trader` and base branch to `main`.
+- Verify the resolved owner, repository, and base branch immediately before creating or updating a pull request.
+- Refuse to create or retarget a pull request whose base repository is the upstream NautilusTrader repository or whose base branch is `develop`.
+- If a tool cannot explicitly guarantee the target repository and branch, stop and report the ambiguity instead of creating the pull request.
+
+## Merges
+
+- Never merge a pull request unless the user explicitly requests that specific merge.
+- Treat approval to create, update, or publish a pull request as distinct from approval to merge it.
+- Do not enable auto-merge unless the user explicitly requests it.
+
+## Report
+
+When publishing work, state the branch source and exact pull request target in the form `arif-b-khan/nautilus_trader:main`. Report that no merge was performed unless the user explicitly requested one.

--- a/.codex/skills/fork-pr-policy/agents/openai.yaml
+++ b/.codex/skills/fork-pr-policy/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Fork PR Policy"
+  short_description: "Keep branches and PRs anchored to the fork"
+  default_prompt: "Use $fork-pr-policy to prepare this branch and pull request safely."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,14 +75,15 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1172e33a862030da77768c11cf17a1f801590de94cf518392b65207f15810c8"
+checksum = "d9677ab3454c237abe6307805bea17a7912b3a516b606c7b4d3d948b9fede137"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
  "alloy-core",
  "alloy-eips",
+ "alloy-ens",
  "alloy-network",
  "alloy-provider",
  "alloy-rpc-client",
@@ -94,20 +95,20 @@ dependencies = [
 
 [[package]]
 name = "alloy-chains"
-version = "0.2.34"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84e0378e959aa6a885897522080a990e80eb317f1e9a222a604492ea50e13096"
+checksum = "3b5cc30538e90795a57647bef8d8864aad6e8d86190617009b4ef8d8b647b49a"
 dependencies = [
  "alloy-primitives",
  "num_enum",
- "strum 0.27.2",
+ "phf 0.14.0",
 ]
 
 [[package]]
 name = "alloy-consensus"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b44937ce84d2cbf1ee4010667bd9214bb7db134a91dd9ffa6b1b8b1d6b030449"
+checksum = "a6ff0c4adba2abdcd9fb5829ae5f4394c06f8585ed283a9ba79aa33763c802e1"
 dependencies = [
  "alloy-eips",
  "alloy-primitives",
@@ -132,9 +133,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus-any"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bb0bdd61ddff726026676450e7e6a52c68aa39d98f2d60d05ad7caaea5b8100"
+checksum = "7cdf48932b1db3216175e19a2b476d89d53076e004850ee7983c6807ba0fde74"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -146,9 +147,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1475c7edc6780b1759ccdb7960e28d29856ecbed47cfcf9e25be6a5f48b0cfb"
+checksum = "ee5c8b5baa015ef1d07a33983794e1539cce36954846a9bc6e1050d8a1ebf9b7"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -250,9 +251,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "154b0f566ebbfc256b63c8d643c6a299f40a6fcd50a9d756c1d191487dd06483"
+checksum = "ea4c0453065b9206acc0f869a258dc8dcbbd595e144b4446f2c493a24a814d1f"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -272,6 +273,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-ens"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709ddd5c63a05ac3274143ed0589e129119206f65cf094d2e727499da23efae8"
+dependencies = [
+ "alloy-contract",
+ "alloy-primitives",
+ "alloy-provider",
+ "alloy-sol-types",
+ "async-trait",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alloy-json-abi"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -285,13 +300,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e92108767c8c95b5e521570e039e374e65198c4179a98d200412c083d6c26d5"
+checksum = "c4691c60de5d628533752cd07e102d17c47874c06c04c91af33960fd94c484f4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "http",
+ "http 1.4.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -300,9 +315,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4546c9fae2861d4159ee3b25c44ab3edb90f21b849e86cf2086cacb1d56d8ac"
+checksum = "9d912bb639bf4ac31e83095afe9e907c8b9774ce0c405966228368309fcfc45f"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -326,9 +341,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2c325d5934445209c8d22fc67d27e2cf9fb79054b8154d9e522d6a4ee3a4f7"
+checksum = "d875a11bd98595f57f73890f2e36f4a1cca0fa670623e59c9fb08b2389979c36"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -367,9 +382,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff4536d25780fcf51a338c26153c526c99649be1273600684ef10b397a207d4a"
+checksum = "0e7d526d184d392a8fbcf4293e457789b307bb70646e4f8b902989a246529450"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -406,9 +421,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc90b1e703d3c03f4ff7f48e82dd0bc1c8211ab7d079cd836a06fcfeb06651cb"
+checksum = "24671b1f62edcf0f9b62994c7bf72cd621a04a4b99f5020ece1a647b40e2f103"
 dependencies = [
  "alloy-rlp-derive",
  "arrayvec",
@@ -417,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rlp-derive"
-version = "0.3.15"
+version = "0.3.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f36834a5c0a2fa56e171bf256c34d70fca07d0c0031583edea1c4946b7889c9e"
+checksum = "9d4311c03125e8a18296504560b9de3d75ecbd0dcda7f71e6cf2a196d57e6fba"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -428,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f8d765656f02f993fa0565abeb3554ccd6a0d72ea44ce0558b983136639bd6b"
+checksum = "755447dc13a04c6fa6db8dedb5d32ab5edfa4dd7aa34487ff192a3d873e0e8cf"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives",
@@ -451,9 +466,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b06bfe79149dd53de5b196aa3c96db0500b7cf0ed72dbd1a31bac7660bc7cc65"
+checksum = "911a513723ef0b90c3b072f65eebf54d6ebc8b651d06734e252d024bd89b88ac"
 dependencies = [
  "alloy-consensus-any",
  "alloy-network-primitives",
@@ -466,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b41d1a11f58b456c199e04591befc64cb236fa2574a7275a07b98b173727bd39"
+checksum = "4e1bd19904581ee2075b61faabab1a4cefa8b96d8f2c85343adeae8ecf615e2b"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -487,9 +502,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcf028ac8bcb161ad7c104243e710cece8e1a794f65ee6c35c4c4d693c8e80ee"
+checksum = "c1e97b3e0b9f816b25083045dcfa69431bd059a078e828e4d82d296d1949b96c"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -498,9 +513,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a5f392f2f56b2417ea6b74e1e116c6f35df5ab5fce4dc422e277d72ee18ff7b"
+checksum = "6913d06ccc0d9c6ab67e2f82e2fbe292706da1f91442f30cded2d04b56bf0d58"
 dependencies = [
  "alloy-primitives",
  "async-trait",
@@ -513,9 +528,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78de3d4ed62e2c90e16be166d0ddfe41944bb5979752703199073acf976083f2"
+checksum = "c880813cd26bd1ddf8c2236e31295896efd1fcc5cc761d8894ae894503aeea53"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -602,13 +617,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39f42ee1ef30d4d3d8b4ea5794937fccfc69e2bb1cd5bcf42d62afc57b049081"
+checksum = "999adfe5c91035c6bf4c4210e0eb8d0caed79d76fbf5e1b70d78721f6097ac04"
 dependencies = [
  "alloy-json-rpc",
  "auto_impl",
- "base64",
+ "base64 0.22.1",
  "derive_more 2.1.1",
  "futures",
  "futures-utils-wasm",
@@ -625,9 +640,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee68bc7d713e033eeaaecb8fd13d5d8a41af97226c4388930ad459285b8e9f70"
+checksum = "0e79a2c1793afc61eed9ca0963da370a988b27d2bbfa67c78013e262d47424c4"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -657,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-tx-macros"
-version = "2.1.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc2cd27809c88c413e5542dbd5a8eff8c12f0086af920e881ae586d3a787d5e5"
+checksum = "406bc1183f6843e0aba09f7b3365e828b597213d60793ba5cb41befc863e3a78"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1181,7 +1196,7 @@ dependencies = [
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "half",
  "lexical-core",
@@ -1202,7 +1217,7 @@ dependencies = [
  "arrow-schema 58.3.0",
  "arrow-select 58.3.0",
  "atoi",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "comfy-table",
  "half",
@@ -1412,7 +1427,7 @@ version = "58.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f633dbfdf39c039ada1bf9e34c694816eb71fbb7dc78f613993b7245e078a1ed"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "serde_core",
  "serde_json",
 ]
@@ -1655,14 +1670,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "itoa",
  "matchit",
@@ -1674,10 +1689,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1 0.10.6",
- "sync_wrapper",
+ "sha1 0.10.7",
+ "sync_wrapper 1.0.2",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -1691,12 +1706,12 @@ checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
  "mime",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tower-layer",
  "tower-service",
 ]
@@ -1715,6 +1730,12 @@ name = "base16ct"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
+name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 
 [[package]]
 name = "base64"
@@ -1830,6 +1851,12 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
@@ -1908,15 +1935,15 @@ version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c9d0a013e3d3ee4edd61e779adf117944c08902d375f18630a0c5b8f95659734"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bollard-stubs",
  "bytes",
  "futures-core",
  "futures-util",
  "hex",
- "http",
+ "http 1.4.2",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-named-pipe",
  "hyper-util",
  "hyperlocal",
@@ -2073,9 +2100,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -2091,9 +2118,9 @@ dependencies = [
 
 [[package]]
 name = "c-kzg"
-version = "2.1.7"
+version = "2.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6648ed1e4ea8e8a1a4a2c78e1cda29a3fd500bc622899c340d8525ea9a76b24a"
+checksum = "38d04308254695569fdb9bfe3bacc1c91837a670d0806605eb82d63748fbd3a6"
 dependencies = [
  "blst",
  "cc",
@@ -2434,6 +2461,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -3181,7 +3218,7 @@ checksum = "14872c47bfc3d21e53ec82f57074e6987a15941c1e2f43cde4ac6ae2746634e3"
 dependencies = [
  "arrow 58.3.0",
  "arrow-buffer 58.3.0",
- "base64",
+ "base64 0.22.1",
  "chrono",
  "chrono-tz",
  "datafusion-common",
@@ -3827,6 +3864,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "enum-ordinalize"
 version = "4.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4021,7 +4067,7 @@ version = "25.12.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35f6839d7b3b98adde531effaf34f0c2badc6f4735d26fe74709d8e513a96ef3"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "rustc_version 0.4.1",
 ]
 
@@ -4073,6 +4119,21 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -4284,6 +4345,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
@@ -4293,7 +4373,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http",
+ "http 1.4.2",
  "indexmap 2.14.0",
  "slab",
  "tokio",
@@ -4435,6 +4515,17 @@ dependencies = [
 
 [[package]]
 name = "http"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
@@ -4445,12 +4536,23 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -4461,8 +4563,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -4495,6 +4597,30 @@ dependencies = [
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
@@ -4503,9 +4629,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -4522,7 +4648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b7d8abf35697b81a825e386fc151e0d503e8cb5fcb93cc8669c376dfd6f278"
 dependencies = [
  "hex",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -4536,8 +4662,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http",
- "hyper",
+ "http 1.4.2",
+ "hyper 1.10.1",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -4552,11 +4678,24 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
  "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -4565,13 +4704,13 @@ version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
- "http",
- "http-body",
- "hyper",
+ "http 1.4.2",
+ "http-body 1.0.1",
+ "hyper 1.10.1",
  "ipnet",
  "libc",
  "percent-encoding",
@@ -4590,7 +4729,7 @@ checksum = "986c5ce3b994526b3cd75578e62554abd09f0899d6206de48b3e96ab34ccc8c7"
 dependencies = [
  "hex",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -5441,6 +5580,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "034a0ad7deebf0c2abcf2435950a6666c3c15ea9d8fad0c0f48efa8a7f843fed"
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "nautilus-analysis"
 version = "0.61.0"
 dependencies = [
@@ -5494,7 +5650,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -5577,7 +5733,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -5596,7 +5752,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "criterion",
@@ -5625,7 +5781,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -5669,7 +5825,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -5710,7 +5866,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "turmoil",
@@ -5757,7 +5913,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -5795,7 +5951,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "dotenvy",
@@ -5820,7 +5976,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "url",
@@ -5917,7 +6073,7 @@ version = "0.61.0"
 dependencies = [
  "anyhow",
  "aws-lc-rs",
- "base64",
+ "base64 0.22.1",
  "ed25519-dalek",
  "log",
  "nautilus-core",
@@ -6040,7 +6196,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -6084,7 +6240,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "ustr",
  "zeroize",
@@ -6100,7 +6256,7 @@ dependencies = [
  "async-stream",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "cosmrs",
@@ -6130,7 +6286,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "tonic",
@@ -6238,7 +6394,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "url",
@@ -6350,7 +6506,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "criterion",
@@ -6383,7 +6539,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -6399,7 +6555,7 @@ dependencies = [
  "arc-swap",
  "async-trait",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "criterion",
@@ -6431,7 +6587,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "url",
  "ustr",
@@ -6516,14 +6672,14 @@ dependencies = [
  "ahash 0.8.12",
  "anyhow",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "bytes",
  "criterion",
  "dashmap",
  "futures",
  "futures-util",
- "http",
+ "http 1.4.2",
  "log",
  "madsim",
  "nautilus-common",
@@ -6538,7 +6694,7 @@ dependencies = [
  "reqwest 0.13.4",
  "rstest",
  "rustls",
- "rustls-pemfile",
+ "rustls-pemfile 2.2.0",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6548,7 +6704,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "turmoil",
  "url",
@@ -6567,7 +6723,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "criterion",
@@ -6596,11 +6752,27 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
  "zeroize",
+]
+
+[[package]]
+name = "nautilus-openalgo"
+version = "0.61.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "nautilus-core",
+ "nautilus-model",
+ "openalgo",
+ "pyo3",
+ "pyo3-async-runtimes",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -6670,7 +6842,7 @@ dependencies = [
  "async-trait",
  "aws-lc-rs",
  "axum",
- "base64",
+ "base64 0.22.1",
  "bon",
  "chrono",
  "criterion",
@@ -6703,7 +6875,7 @@ dependencies = [
  "strum 0.28.0",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "url",
@@ -6766,6 +6938,7 @@ dependencies = [
  "nautilus-model",
  "nautilus-network",
  "nautilus-okx",
+ "nautilus-openalgo",
  "nautilus-persistence",
  "nautilus-polymarket",
  "nautilus-portfolio",
@@ -6927,7 +7100,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
  "ustr",
@@ -7161,7 +7334,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -7181,18 +7354,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "622acbc9100d3c10e2ee15804b0caa40e55c933d5aa53814cd520805b7958a49"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
  "chrono",
  "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-util",
- "http",
+ "http 1.4.2",
  "http-body-util",
  "httparse",
  "humantime",
- "hyper",
+ "hyper 1.10.1",
  "itertools 0.14.0",
  "md-5 0.10.6",
  "parking_lot",
@@ -7248,10 +7421,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "openalgo"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63f464ef4c8f886e328ca7f3856a47a862473d7f0d978560026b923e67ffa5ef"
+dependencies = [
+ "futures-util",
+ "log",
+ "reqwest 0.11.27",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-tungstenite 0.21.0",
+ "url",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77823a27f0babb03091cb9ed9ef80af3b39dbc82f97e8fa530374b7dafd87a45"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.117"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b47e7e6bb2c38cd930d25a23b40fa52e068c10e85f3e03a7f5ba5aaca5713695"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "ordered-float"
@@ -7360,7 +7587,7 @@ dependencies = [
  "arrow-ipc 57.3.1",
  "arrow-schema 57.3.1",
  "arrow-select 57.3.1",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -7395,7 +7622,7 @@ dependencies = [
  "arrow-ipc 58.3.0",
  "arrow-schema 58.3.0",
  "arrow-select 58.3.0",
- "base64",
+ "base64 0.22.1",
  "brotli",
  "bytes",
  "chrono",
@@ -7439,7 +7666,7 @@ version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "serde_core",
 ]
 
@@ -7500,6 +7727,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_codegen"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7533,6 +7769,15 @@ name = "phf_shared"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06005508882fb681fd97892ecff4b7fd0fee13ef1aa569f8695dae7ab9099981"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -7694,7 +7939,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha 0.9.0",
@@ -8228,7 +8473,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -8253,9 +8498,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.12.4"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1292b7759ae1cb9ec195452d1390a074f0cd8541ab7a5a8c31cd6db45d4a6ba"
+checksum = "2a0e75113e14dc5acb068cd0786884f214f1312650a3d36d269f5c4f3cdee8a2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8265,9 +8510,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "1f388202e4b80542a0921078cc23b6333bcf1409c1e3f86404cae4766a6131db"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -8297,19 +8542,59 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile 1.0.4",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -8323,7 +8608,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -8343,16 +8628,16 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
@@ -8366,7 +8651,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
@@ -8629,7 +8914,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -8666,6 +8951,15 @@ dependencies = [
 
 [[package]]
 name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
@@ -8689,7 +8983,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "jni",
  "log",
@@ -8975,8 +9269,8 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags",
- "core-foundation",
+ "bitflags 2.13.0",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -9147,7 +9441,7 @@ version = "3.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76a5c54c7310e7b8b9577c286d7e399ddd876c3e12b3ed917a8aabc4b96e9e8c"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bs58",
  "chrono",
  "hex",
@@ -9198,9 +9492,9 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "a978451301f4db1d02937a4ab3ccce137717b81826e79b7d49ffe3244a13c3b8"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
@@ -9383,7 +9677,7 @@ version = "1.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4acad755d1e9548ba9f2a32efeb83e18eefd25f61907cf66e7653364a40ec990"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "dashmap",
  "fastrand",
@@ -9393,7 +9687,7 @@ dependencies = [
  "parking_lot",
  "pin-project-lite",
  "rustls",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "simdutf8",
  "socket2 0.5.10",
  "tokio",
@@ -9461,7 +9755,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "bytes",
  "cfg-if",
  "crc",
@@ -9534,7 +9828,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "crc",
@@ -9562,8 +9856,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
- "base64",
- "bitflags",
+ "base64 0.22.1",
+ "bitflags 2.13.0",
  "byteorder",
  "crc",
  "dotenvy",
@@ -9655,9 +9949,6 @@ name = "strum"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
-dependencies = [
- "strum_macros 0.27.2",
-]
 
 [[package]]
 name = "strum"
@@ -9749,6 +10040,12 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -9769,9 +10066,9 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.39.5"
+version = "0.39.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8bd2130a9b60bee2581bf82cfe89ee836424d1f37dcfa4ce21509611684673"
+checksum = "d2071df9448915b71c4fe6d25deaf1c22f12bd234f01540b77312bb8e41361e6"
 dependencies = [
  "libc",
  "memchr",
@@ -9779,6 +10076,27 @@ dependencies = [
  "objc2-core-foundation",
  "objc2-io-kit",
  "windows",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -9912,9 +10230,9 @@ dependencies = [
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "1ad99c4c6d32803332c548b1af0540b357b3f5fc0be8f6c6bfe8b2e6ae784070"
 dependencies = [
  "cfg-if",
 ]
@@ -10019,9 +10337,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+checksum = "bb4ebadaa0af04fab11ae01eb5f9fdb5f9c5b875506e210e71c07873528baa7f"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -10061,6 +10379,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10084,6 +10412,20 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c83b561d025642014097b66e6c1bb422783339e0909e4429cde4749d1990bc38"
+dependencies = [
+ "futures-util",
+ "log",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tungstenite 0.21.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -10094,7 +10436,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite",
+ "tungstenite 0.29.0",
  "webpki-roots 0.26.11",
 ]
 
@@ -10193,13 +10535,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "base64",
+ "base64 0.22.1",
  "bytes",
- "h2",
- "http",
- "http-body",
+ "h2 0.4.15",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.10.1",
  "hyper-timeout",
  "hyper-util",
  "percent-encoding",
@@ -10254,7 +10596,7 @@ dependencies = [
  "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
  "tokio",
  "tokio-util",
  "tower-layer",
@@ -10268,11 +10610,11 @@ version = "0.6.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http",
- "http-body",
+ "http 1.4.2",
+ "http-body 1.0.1",
  "pin-project-lite",
  "tower",
  "tower-layer",
@@ -10362,19 +10704,39 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ef1a641ea34f399a848dea702823bbecfb4c486f911735368f1f137cb8257e1"
+dependencies = [
+ "byteorder",
+ "bytes",
+ "data-encoding",
+ "http 1.4.2",
+ "httparse",
+ "log",
+ "native-tls",
+ "rand 0.8.6",
+ "sha1 0.10.7",
+ "thiserror 1.0.69",
+ "url",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
 dependencies = [
  "bytes",
  "data-encoding",
- "http",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1 0.10.6",
+ "sha1 0.10.7",
  "thiserror 2.0.18",
 ]
 
@@ -10600,6 +10962,12 @@ dependencies = [
  "parking_lot",
  "serde",
 ]
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8_iter"
@@ -10976,11 +11344,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -10994,18 +11371,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -11019,15 +11411,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -11043,9 +11453,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -11055,9 +11477,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -11078,6 +11512,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.50.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -11172,18 +11616,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75726053136156d419e285b9b7eddaaea9e3fea6ce32eed44a89901f0bd98de1"
+checksum = "b7cbbc0a705a0fd05cc3676525980d2bf5a9bc4adac6d6475209a7887cf59d19"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.53"
+version = "0.8.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4714fd92cf900833d49538023a9b3915155210801d1c1169eba513b2addefd71"
+checksum = "e2e817b7b52d0c7358d3246da9d69935ebb18116b2b102b4230dac079b4862f5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11266,9 +11710,9 @@ dependencies = [
 
 [[package]]
 name = "zlib-rs"
-version = "0.6.5"
+version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5431d5661c32445236631278f27946e444ddafe4684cac70b185272d4f9c52d5"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/adapters/okx",
   "crates/adapters/polymarket",
   "crates/adapters/sandbox",
+  "crates/adapters/openalgo",
   "crates/adapters/tardis",
   "crates/analysis",
   "crates/backtest",
@@ -115,6 +116,7 @@ nautilus-lighter = { path = "crates/adapters/lighter", version = "0.61.0", defau
 nautilus-okx = { path = "crates/adapters/okx", version = "0.61.0", default-features = false }
 nautilus-polymarket = { path = "crates/adapters/polymarket", version = "0.61.0", default-features = false }
 nautilus-sandbox = { path = "crates/adapters/sandbox", version = "0.61.0", default-features = false }
+nautilus-openalgo = { path = "crates/adapters/openalgo", version = "0.61.0", default-features = false }
 nautilus-tardis = { path = "crates/adapters/tardis", version = "0.61.0", default-features = false }
 
 # -----------------------------------------------------------------------------
@@ -191,6 +193,7 @@ mimalloc = "0.1.52"
 object_store = { version = "0.13.2", default-features = false, features = [
   "fs",
 ] }
+openalgo = "=1.0.5"
 parquet = { version = "58.3.0", default-features = false, features = [
   "arrow",
   "async",

--- a/crates/adapters/openalgo/Cargo.toml
+++ b/crates/adapters/openalgo/Cargo.toml
@@ -1,0 +1,58 @@
+[package]
+name = "nautilus-openalgo"
+readme = "README.md"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+description = "OpenAlgo integration adapter for the Nautilus trading engine"
+categories.workspace = true
+keywords.workspace = true
+documentation.workspace = true
+repository.workspace = true
+homepage.workspace = true
+publish = false # Do not publish to crates.io yet
+
+[lints]
+workspace = true
+
+[lib]
+name = "nautilus_openalgo"
+crate-type = ["rlib", "cdylib"]
+
+[features]
+default = ["high-precision"]
+extension-module = [
+  "nautilus-core/extension-module",
+  "nautilus-model/extension-module",
+  "python",
+  "pyo3/extension-module",
+]
+python = [
+  "nautilus-core/python",
+  "nautilus-model/python",
+  "pyo3",
+  "pyo3-async-runtimes",
+]
+high-precision = ["nautilus-model/high-precision"]
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]
+
+[dependencies]
+nautilus-core = { workspace = true }
+nautilus-model = { workspace = true }
+
+anyhow = { workspace = true }
+openalgo = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+pyo3 = { workspace = true, optional = true }
+pyo3-async-runtimes = { workspace = true, optional = true }
+
+[dev-dependencies]
+axum = { workspace = true }
+tokio = { workspace = true }

--- a/crates/adapters/openalgo/README.md
+++ b/crates/adapters/openalgo/README.md
@@ -1,0 +1,3 @@
+# Nautilus OpenAlgo Adapter
+
+OpenAlgo integration adapter for NautilusTrader.

--- a/crates/adapters/openalgo/src/http/client.rs
+++ b/crates/adapters/openalgo/src/http/client.rs
@@ -1,0 +1,229 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use anyhow::Result;
+use openalgo::OpenAlgo;
+use serde::Serialize;
+use std::{fmt, sync::Arc};
+
+#[cfg_attr(
+    feature = "python",
+    pyo3::pyclass(module = "nautilus_trader._libnautilus.openalgo")
+)]
+#[derive(Clone)]
+pub struct OpenAlgoHttpClient {
+    inner: Arc<OpenAlgo>,
+}
+
+impl OpenAlgoHttpClient {
+    #[must_use]
+    pub fn new(api_key: &str, host: &str, version: &str, ws_url: &str) -> Self {
+        Self {
+            inner: Arc::new(OpenAlgo::with_config(api_key, host, version, ws_url)),
+        }
+    }
+
+    pub async fn place_order(
+        &self,
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+        price: Option<&str>,
+        trigger_price: Option<&str>,
+    ) -> Result<String> {
+        let pricetype_upper = pricetype.to_ascii_uppercase();
+        let response = match pricetype_upper.as_str() {
+            "LIMIT" => {
+                self.inner
+                    .place_limit_order(
+                        strategy,
+                        symbol,
+                        action,
+                        exchange,
+                        product,
+                        quantity,
+                        price.unwrap_or("0"),
+                    )
+                    .await?
+            }
+            "SL" => {
+                self.inner
+                    .place_sl_order(
+                        strategy,
+                        symbol,
+                        action,
+                        exchange,
+                        product,
+                        quantity,
+                        price.unwrap_or("0"),
+                        trigger_price.unwrap_or("0"),
+                    )
+                    .await?
+            }
+            _ => {
+                self.inner
+                    .place_order(
+                        strategy, symbol, action, exchange, pricetype, product, quantity,
+                    )
+                    .await?
+            }
+        };
+
+        to_json(response)
+    }
+
+    pub async fn modify_order(
+        &self,
+        orderid: &str,
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+        price: &str,
+    ) -> Result<String> {
+        let response = self
+            .inner
+            .modify_order(
+                orderid, strategy, symbol, action, exchange, pricetype, product, quantity, price,
+            )
+            .await?;
+        to_json(response)
+    }
+
+    pub async fn cancel_order(&self, orderid: &str, strategy: &str) -> Result<String> {
+        let response = self.inner.cancel_order(orderid, strategy).await?;
+        to_json(response)
+    }
+
+    pub async fn cancel_all_order(&self, strategy: &str) -> Result<String> {
+        let response = self.inner.cancel_all_order(strategy).await?;
+        to_json(response)
+    }
+
+    pub async fn order_status(&self, orderid: &str, strategy: &str) -> Result<String> {
+        let response = self.inner.order_status(orderid, strategy).await?;
+        to_json(response)
+    }
+
+    pub async fn funds(&self) -> Result<String> {
+        let response = self.inner.funds().await?;
+        to_json(response)
+    }
+
+    pub async fn orderbook(&self) -> Result<String> {
+        let response = self.inner.orderbook().await?;
+        to_json(response)
+    }
+
+    pub async fn tradebook(&self) -> Result<String> {
+        let response = self.inner.tradebook().await?;
+        to_json(response)
+    }
+
+    pub async fn positionbook(&self) -> Result<String> {
+        let response = self.inner.positionbook().await?;
+        to_json(response)
+    }
+}
+
+fn to_json<T: Serialize>(value: T) -> Result<String> {
+    Ok(serde_json::to_string(&value)?)
+}
+
+impl fmt::Debug for OpenAlgoHttpClient {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("OpenAlgoHttpClient").finish_non_exhaustive()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use axum::{Json, Router, extract::State, routing::post};
+    use serde_json::{Value, json};
+    use tokio::{net::TcpListener, sync::Mutex};
+
+    use super::*;
+
+    type RequestCapture = Arc<Mutex<Option<Value>>>;
+
+    #[tokio::test]
+    async fn place_limit_order_uses_openalgo_sdk_endpoint_and_payload() {
+        let captured: RequestCapture = Arc::new(Mutex::new(None));
+        let app = Router::new()
+            .route("/api/v1/placeorder", post(capture_place_order))
+            .with_state(captured.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host = format!("http://{}", listener.local_addr().unwrap());
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        let client = OpenAlgoHttpClient::new("KEY", &host, "v1", "ws://127.0.0.1:8765");
+        let raw = client
+            .place_order(
+                "NautilusTrader",
+                "RELIANCE",
+                "BUY",
+                "NSE",
+                "LIMIT",
+                "MIS",
+                "1",
+                Some("2500.00"),
+                None,
+            )
+            .await
+            .unwrap();
+
+        let response: Value = serde_json::from_str(&raw).unwrap();
+        assert_eq!(
+            response,
+            json!({"status": "success", "orderid": "250408000989443", "message": null})
+        );
+
+        let request = captured.lock().await.take().unwrap();
+        assert_eq!(
+            request,
+            json!({
+                "apikey": "KEY",
+                "strategy": "NautilusTrader",
+                "symbol": "RELIANCE",
+                "action": "BUY",
+                "exchange": "NSE",
+                "pricetype": "LIMIT",
+                "product": "MIS",
+                "quantity": "1",
+                "price": "2500.00"
+            })
+        );
+    }
+
+    async fn capture_place_order(
+        State(captured): State<RequestCapture>,
+        Json(payload): Json<Value>,
+    ) -> Json<Value> {
+        *captured.lock().await = Some(payload);
+        Json(json!({"status": "success", "orderid": "250408000989443"}))
+    }
+}

--- a/crates/adapters/openalgo/src/http/mod.rs
+++ b/crates/adapters/openalgo/src/http/mod.rs
@@ -1,0 +1,16 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+pub mod client;

--- a/crates/adapters/openalgo/src/lib.rs
+++ b/crates/adapters/openalgo/src/lib.rs
@@ -1,0 +1,30 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! [NautilusTrader](http://nautilustrader.io) adapter for [OpenAlgo](https://openalgo.in).
+
+#![warn(rustc::all)]
+#![deny(unsafe_code)]
+#![deny(nonstandard_style)]
+#![deny(missing_debug_implementations)]
+#![deny(clippy::missing_panics_doc)]
+#![deny(rustdoc::broken_intra_doc_links)]
+
+pub mod http;
+
+#[cfg(feature = "python")]
+pub mod python;
+
+pub use crate::http::client::OpenAlgoHttpClient;

--- a/crates/adapters/openalgo/src/python/http.rs
+++ b/crates/adapters/openalgo/src/python/http.rs
@@ -1,0 +1,252 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use nautilus_core::python::to_pyvalue_err;
+use pyo3::prelude::*;
+
+use crate::http::client::OpenAlgoHttpClient;
+
+#[pymethods]
+impl OpenAlgoHttpClient {
+    #[new]
+    #[pyo3(signature = (api_key=None, host="http://127.0.0.1:5000", version="v1", ws_url="ws://127.0.0.1:8765", timeout_secs=None, proxy_url=None))]
+    fn py_new(
+        api_key: Option<String>,
+        host: &str,
+        version: &str,
+        ws_url: &str,
+        timeout_secs: Option<u64>,
+        proxy_url: Option<String>,
+    ) -> PyResult<Self> {
+        let _ = (timeout_secs, proxy_url);
+        let api_key = api_key
+            .or_else(|| std::env::var("OPENALGO_API_KEY").ok())
+            .ok_or_else(|| {
+                pyo3::exceptions::PyValueError::new_err(
+                    "OpenAlgo API key not provided; set api_key or OPENALGO_API_KEY",
+                )
+            })?;
+
+        Ok(Self::new(&api_key, host, version, ws_url))
+    }
+
+    #[pyo3(name = "connect")]
+    fn py_connect<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(()) })
+    }
+
+    #[pyo3(name = "close")]
+    fn py_close<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        pyo3_async_runtimes::tokio::future_into_py(py, async move { Ok(()) })
+    }
+
+    #[pyo3(name = "place_order", signature = (strategy, symbol, action, exchange, pricetype, product, quantity, price=None, trigger_price=None))]
+    fn py_place_order<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+        price: Option<&str>,
+        trigger_price: Option<&str>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        let args = OrderArgs::new(
+            strategy, symbol, action, exchange, pricetype, product, quantity,
+        );
+        let price = price.map(str::to_string);
+        let trigger_price = trigger_price.map(str::to_string);
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .place_order(
+                    &args.strategy,
+                    &args.symbol,
+                    &args.action,
+                    &args.exchange,
+                    &args.pricetype,
+                    &args.product,
+                    &args.quantity,
+                    price.as_deref(),
+                    trigger_price.as_deref(),
+                )
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "modify_order")]
+    fn py_modify_order<'py>(
+        &self,
+        py: Python<'py>,
+        orderid: &str,
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+        price: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        let orderid = orderid.to_string();
+        let args = OrderArgs::new(
+            strategy, symbol, action, exchange, pricetype, product, quantity,
+        );
+        let price = price.to_string();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .modify_order(
+                    &orderid,
+                    &args.strategy,
+                    &args.symbol,
+                    &args.action,
+                    &args.exchange,
+                    &args.pricetype,
+                    &args.product,
+                    &args.quantity,
+                    &price,
+                )
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "cancel_order")]
+    fn py_cancel_order<'py>(
+        &self,
+        py: Python<'py>,
+        orderid: &str,
+        strategy: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        let orderid = orderid.to_string();
+        let strategy = strategy.to_string();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .cancel_order(&orderid, &strategy)
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "cancel_all_order")]
+    fn py_cancel_all_order<'py>(
+        &self,
+        py: Python<'py>,
+        strategy: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        let strategy = strategy.to_string();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .cancel_all_order(&strategy)
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "order_status")]
+    fn py_order_status<'py>(
+        &self,
+        py: Python<'py>,
+        orderid: &str,
+        strategy: &str,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        let orderid = orderid.to_string();
+        let strategy = strategy.to_string();
+
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client
+                .order_status(&orderid, &strategy)
+                .await
+                .map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "funds")]
+    fn py_funds<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client.funds().await.map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "orderbook")]
+    fn py_orderbook<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client.orderbook().await.map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "tradebook")]
+    fn py_tradebook<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client.tradebook().await.map_err(to_pyvalue_err)
+        })
+    }
+
+    #[pyo3(name = "positionbook")]
+    fn py_positionbook<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyAny>> {
+        let client = self.clone();
+        pyo3_async_runtimes::tokio::future_into_py(py, async move {
+            client.positionbook().await.map_err(to_pyvalue_err)
+        })
+    }
+}
+
+#[derive(Debug)]
+struct OrderArgs {
+    strategy: String,
+    symbol: String,
+    action: String,
+    exchange: String,
+    pricetype: String,
+    product: String,
+    quantity: String,
+}
+
+impl OrderArgs {
+    fn new(
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+    ) -> Self {
+        Self {
+            strategy: strategy.to_string(),
+            symbol: symbol.to_string(),
+            action: action.to_string(),
+            exchange: exchange.to_string(),
+            pricetype: pricetype.to_string(),
+            product: product.to_string(),
+            quantity: quantity.to_string(),
+        }
+    }
+}

--- a/crates/adapters/openalgo/src/python/mod.rs
+++ b/crates/adapters/openalgo/src/python/mod.rs
@@ -1,0 +1,27 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+//! Python bindings from `pyo3`.
+
+pub mod http;
+
+use pyo3::prelude::*;
+
+/// Loaded as `nautilus_pyo3.openalgo`.
+#[pymodule]
+pub fn openalgo(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<crate::http::client::OpenAlgoHttpClient>()?;
+    Ok(())
+}

--- a/crates/adapters/openalgo/tests/simple_strategy_smoke.rs
+++ b/crates/adapters/openalgo/tests/simple_strategy_smoke.rs
@@ -1,0 +1,104 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::sync::Arc;
+
+use axum::{Json, Router, extract::State, routing::post};
+use nautilus_openalgo::OpenAlgoHttpClient;
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, sync::Mutex};
+
+type RequestCapture = Arc<Mutex<Option<Value>>>;
+
+#[derive(Debug)]
+struct SimpleOpenAlgoStrategy {
+    client: OpenAlgoHttpClient,
+    strategy: &'static str,
+    symbol: &'static str,
+    exchange: &'static str,
+    product: &'static str,
+}
+
+impl SimpleOpenAlgoStrategy {
+    async fn buy_once(&self) -> anyhow::Result<Value> {
+        let raw = self
+            .client
+            .place_order(
+                self.strategy,
+                self.symbol,
+                "BUY",
+                self.exchange,
+                "MARKET",
+                self.product,
+                "1",
+                None,
+                None,
+            )
+            .await?;
+
+        Ok(serde_json::from_str(&raw)?)
+    }
+}
+
+#[tokio::test]
+async fn simple_strategy_places_market_order_through_openalgo_adapter() {
+    let captured: RequestCapture = Arc::new(Mutex::new(None));
+    let app = Router::new()
+        .route("/api/v1/placeorder", post(capture_place_order))
+        .with_state(captured.clone());
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let host = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+
+    let strategy = SimpleOpenAlgoStrategy {
+        client: OpenAlgoHttpClient::new("KEY", &host, "v1", "ws://127.0.0.1:8765"),
+        strategy: "NautilusTrader",
+        symbol: "RELIANCE",
+        exchange: "NSE",
+        product: "MIS",
+    };
+
+    let response = strategy.buy_once().await.unwrap();
+    assert_eq!(
+        response,
+        json!({"status": "success", "orderid": "250408000989443", "message": null})
+    );
+
+    let request = captured.lock().await.take().unwrap();
+    assert_eq!(
+        request,
+        json!({
+            "apikey": "KEY",
+            "strategy": "NautilusTrader",
+            "symbol": "RELIANCE",
+            "action": "BUY",
+            "exchange": "NSE",
+            "pricetype": "MARKET",
+            "product": "MIS",
+            "quantity": "1"
+        })
+    );
+}
+
+async fn capture_place_order(
+    State(captured): State<RequestCapture>,
+    Json(payload): Json<Value>,
+) -> Json<Value> {
+    *captured.lock().await = Some(payload);
+    Json(json!({"status": "success", "orderid": "250408000989443"}))
+}

--- a/crates/pyo3/Cargo.toml
+++ b/crates/pyo3/Cargo.toml
@@ -66,6 +66,7 @@ extension-module = [
   "nautilus-portfolio/extension-module",
   "nautilus-polymarket/extension-module",
   "nautilus-sandbox/extension-module",
+  "nautilus-openalgo/extension-module",
   "nautilus-persistence/extension-module",
   "nautilus-risk/extension-module",
   "nautilus-serialization/extension-module",
@@ -98,6 +99,7 @@ high-precision = [
   "nautilus-okx/high-precision",
   "nautilus-polymarket/high-precision",
   "nautilus-sandbox/high-precision",
+  "nautilus-openalgo/high-precision",
   "nautilus-tardis/high-precision",
 ]
 hypersync = ["defi", "nautilus-blockchain/hypersync"]
@@ -158,6 +160,7 @@ nautilus-lighter = { workspace = true, features = ["python"] }
 nautilus-okx = { workspace = true, features = ["python"] }
 nautilus-polymarket = { workspace = true, features = ["python"] }
 nautilus-sandbox = { workspace = true, features = ["python"] }
+nautilus-openalgo = { workspace = true, features = ["python"] }
 nautilus-tardis = { workspace = true, features = ["python", "replay"] }
 
 # local_dynamic_tls avoids exhausting static TLS space when the extension is dlopen'd

--- a/crates/pyo3/src/lib.rs
+++ b/crates/pyo3/src/lib.rs
@@ -344,6 +344,13 @@ fn _libnautilus(py: Python<'_>, m: &Bound<'_, PyModule>) -> PyResult<()> {
     #[cfg(feature = "cython-compat")]
     re_export_module_attributes(m, n)?;
 
+    let n = "openalgo";
+    let submodule = pyo3::wrap_pymodule!(nautilus_openalgo::python::openalgo);
+    m.add_wrapped(submodule)?;
+    sys_modules.set_item(format!("{module_name}.{n}"), m.getattr(n)?)?;
+    #[cfg(feature = "cython-compat")]
+    re_export_module_attributes(m, n)?;
+
     let n = "tardis";
     let submodule = pyo3::wrap_pymodule!(nautilus_tardis::python::tardis);
     m.add_wrapped(submodule)?;

--- a/nautilus_trader/adapters/env.py
+++ b/nautilus_trader/adapters/env.py
@@ -14,17 +14,90 @@
 # -------------------------------------------------------------------------------------------------
 
 import os
+from pathlib import Path
+
+
+def _read_secret_file(path: Path) -> str:
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _get_key_from_file_env(key: str) -> str | None:
+    file_key = f"{key}_FILE"
+    if file_key not in os.environ:
+        return None
+
+    file_path = os.environ[file_key]
+    if not file_path:
+        raise RuntimeError(f"Environment variable '{file_key}' is set but empty")
+
+    try:
+        return _read_secret_file(Path(file_path))
+    except OSError as e:
+        raise RuntimeError(
+            f"Unable to read secret file for '{key}' from '{file_path}'",
+        ) from e
+
+
+def _get_key_from_dotenv(key: str) -> str | None:
+    dotenv_path = Path(os.environ.get("NAUTILUS_DOTENV_FILE") or ".env")
+    if not dotenv_path.is_file():
+        return None
+
+    try:
+        with dotenv_path.open(encoding="utf-8") as f:
+            for raw_line in f:
+                line = raw_line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+
+                k, v = line.split("=", 1)
+                if k.strip() != key:
+                    continue
+
+                value = v.strip()
+                if value and ((value[0] == value[-1]) and value[0] in {'"', "'"}):
+                    value = value[1:-1]
+                return value
+    except OSError as e:
+        raise RuntimeError(f"Unable to read dotenv file '{dotenv_path}'") from e
+
+    return None
+
+
+def _get_key_from_secrets_dir(key: str) -> str | None:
+    secrets_dir = Path(os.environ.get("NAUTILUS_SECRETS_DIR") or "/run/secrets")
+    if not secrets_dir.is_dir():
+        return None
+
+    candidates = (
+        secrets_dir / key,
+        secrets_dir / key.lower(),
+    )
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            return _read_secret_file(path)
+        except OSError as e:
+            raise RuntimeError(f"Unable to read secret file '{path}'") from e
+
+    return None
 
 
 def get_env_key(key: str) -> str:
-    if key not in os.environ:
-        raise RuntimeError(f"Environment variable '{key}' not set")
-    else:
+    if key in os.environ:
         return os.environ[key]
+
+    for resolver in (_get_key_from_file_env, _get_key_from_dotenv, _get_key_from_secrets_dir):
+        value = resolver(key)
+        if value is not None:
+            return value
+
+    raise RuntimeError(f"Environment variable '{key}' not set")
 
 
 def get_env_key_or(key: str, default: str) -> str:
-    if key not in os.environ:
+    try:
+        return get_env_key(key)
+    except RuntimeError:
         return default
-    else:
-        return os.environ[key]

--- a/nautilus_trader/adapters/openalgo/__init__.py
+++ b/nautilus_trader/adapters/openalgo/__init__.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.adapters.openalgo.config import OpenAlgoExecClientConfig
+from nautilus_trader.adapters.openalgo.execution import OpenAlgoExecutionClient
+from nautilus_trader.adapters.openalgo.factories import OpenAlgoLiveExecClientFactory
+from nautilus_trader.adapters.openalgo.factories import get_cached_openalgo_http_client
+from nautilus_trader.adapters.openalgo.factories import get_cached_openalgo_instrument_provider
+from nautilus_trader.adapters.openalgo.providers import OpenAlgoInstrumentProvider
+
+
+__all__ = [
+    "OpenAlgoExecClientConfig",
+    "OpenAlgoExecutionClient",
+    "OpenAlgoInstrumentProvider",
+    "OpenAlgoLiveExecClientFactory",
+    "get_cached_openalgo_http_client",
+    "get_cached_openalgo_instrument_provider",
+]

--- a/nautilus_trader/adapters/openalgo/config.py
+++ b/nautilus_trader/adapters/openalgo/config.py
@@ -1,0 +1,67 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from nautilus_trader.adapters.openalgo.constants import OPENALGO_DEFAULT_API_VERSION
+from nautilus_trader.adapters.openalgo.constants import OPENALGO_DEFAULT_BASE_URL
+from nautilus_trader.adapters.openalgo.constants import OPENALGO_DEFAULT_VENUE
+from nautilus_trader.adapters.openalgo.constants import OPENALGO_DEFAULT_WS_URL
+from nautilus_trader.common.config import PositiveInt
+from nautilus_trader.config import LiveExecClientConfig
+
+
+class OpenAlgoExecClientConfig(LiveExecClientConfig, frozen=True):
+    """
+    Configuration for ``OpenAlgoExecutionClient`` instances.
+
+    Parameters
+    ----------
+    api_key : str, optional
+        The OpenAlgo app API key. If ``None`` then ``OPENALGO_API_KEY`` is used.
+    base_url_http : str, default ``http://127.0.0.1:5000``
+        The OpenAlgo HTTP host.
+    base_url_ws : str, default ``ws://127.0.0.1:8765``
+        The OpenAlgo WebSocket host. Reserved for market-data streaming support.
+    api_version : str, default ``v1``
+        The OpenAlgo REST API version.
+    venue : str, default ``NSE``
+        The Nautilus venue/exchange code for this client instance.
+    product : str, default ``MIS``
+        The OpenAlgo product sent on order requests unless overridden later.
+    strategy : str, default ``NautilusTrader``
+        The OpenAlgo strategy tag sent on order requests.
+    account_id : str, optional
+        The account ID to publish into Nautilus. Defaults to ``OPENALGO-<venue>``.
+    base_currency : str, default ``INR``
+        The account base currency.
+    http_timeout_secs : PositiveInt, default 10
+        The timeout (seconds) for HTTP requests.
+    http_proxy_url : str, optional
+        Optional HTTP proxy URL.
+
+    """
+
+    api_key: str | None = None
+    base_url_http: str = OPENALGO_DEFAULT_BASE_URL
+    base_url_ws: str = OPENALGO_DEFAULT_WS_URL
+    api_version: str = OPENALGO_DEFAULT_API_VERSION
+    venue: str = OPENALGO_DEFAULT_VENUE
+    product: str = "MIS"
+    strategy: str = "NautilusTrader"
+    account_id: str | None = None
+    base_currency: str = "INR"
+    http_timeout_secs: PositiveInt = 10
+    http_proxy_url: str | None = None

--- a/nautilus_trader/adapters/openalgo/config.py
+++ b/nautilus_trader/adapters/openalgo/config.py
@@ -54,7 +54,7 @@ class OpenAlgoExecClientConfig(LiveExecClientConfig, frozen=True):
 
     """
 
-    api_key: str | None = None
+    api_key: str | None = OPENALGO_DEFAULT_API_KEY
     base_url_http: str = OPENALGO_DEFAULT_BASE_URL
     base_url_ws: str = OPENALGO_DEFAULT_WS_URL
     api_version: str = OPENALGO_DEFAULT_API_VERSION

--- a/nautilus_trader/adapters/openalgo/constants.py
+++ b/nautilus_trader/adapters/openalgo/constants.py
@@ -1,0 +1,28 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from typing import Final
+
+from nautilus_trader.model.identifiers import ClientId
+
+
+OPENALGO: Final[str] = "OPENALGO"
+OPENALGO_CLIENT_ID: Final[ClientId] = ClientId(OPENALGO)
+OPENALGO_DEFAULT_BASE_URL: Final[str] = "http://127.0.0.1:5000"
+OPENALGO_DEFAULT_WS_URL: Final[str] = "ws://127.0.0.1:8765"
+OPENALGO_DEFAULT_API_VERSION: Final[str] = "v1"
+OPENALGO_DEFAULT_VENUE: Final[str] = "NSE"

--- a/nautilus_trader/adapters/openalgo/execution.py
+++ b/nautilus_trader/adapters/openalgo/execution.py
@@ -1,0 +1,565 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime
+from decimal import Decimal
+from typing import Any
+
+from nautilus_trader.adapters.openalgo.config import OpenAlgoExecClientConfig
+from nautilus_trader.adapters.openalgo.constants import OPENALGO_CLIENT_ID
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpClient
+from nautilus_trader.adapters.openalgo.providers import OpenAlgoInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.common.enums import LogColor
+from nautilus_trader.core.uuid import UUID4
+from nautilus_trader.execution.messages import BatchCancelOrders
+from nautilus_trader.execution.messages import CancelAllOrders
+from nautilus_trader.execution.messages import CancelOrder
+from nautilus_trader.execution.messages import GenerateFillReports
+from nautilus_trader.execution.messages import GenerateOrderStatusReport
+from nautilus_trader.execution.messages import GenerateOrderStatusReports
+from nautilus_trader.execution.messages import GeneratePositionStatusReports
+from nautilus_trader.execution.messages import ModifyOrder
+from nautilus_trader.execution.messages import QueryAccount
+from nautilus_trader.execution.messages import SubmitOrder
+from nautilus_trader.execution.messages import SubmitOrderList
+from nautilus_trader.execution.reports import FillReport
+from nautilus_trader.execution.reports import OrderStatusReport
+from nautilus_trader.execution.reports import PositionStatusReport
+from nautilus_trader.live.execution_client import LiveExecutionClient
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import LiquiditySide
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import OrderStatus
+from nautilus_trader.model.enums import OrderType
+from nautilus_trader.model.enums import PositionSide
+from nautilus_trader.model.enums import TimeInForce
+from nautilus_trader.model.identifiers import AccountId
+from nautilus_trader.model.identifiers import ClientId
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import TradeId
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.identifiers import VenueOrderId
+from nautilus_trader.model.objects import Currency
+from nautilus_trader.model.objects import Money
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.model.orders import Order
+
+
+class OpenAlgoExecutionClient(LiveExecutionClient):
+    """
+    Provides an execution client for OpenAlgo broker integrations.
+    """
+
+    def __init__(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        client: OpenAlgoHttpClient,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+        instrument_provider: OpenAlgoInstrumentProvider,
+        config: OpenAlgoExecClientConfig,
+        name: str | None = None,
+    ) -> None:
+        venue = Venue(config.venue)
+        base_currency = Currency.from_str(config.base_currency)
+
+        super().__init__(
+            loop=loop,
+            client_id=ClientId(name or OPENALGO_CLIENT_ID.value),
+            venue=venue,
+            oms_type=OmsType.NETTING,
+            account_type=AccountType.CASH,
+            base_currency=base_currency,
+            instrument_provider=instrument_provider,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+        )
+
+        self._client = client
+        self._config = config
+        self._instrument_provider = instrument_provider
+        self._base_currency = base_currency
+
+        account_id = AccountId(config.account_id or f"{OPENALGO_CLIENT_ID.value}-{venue.value}")
+        self._set_account_id(account_id)
+
+        self._log.info(f"config.base_url_http={config.base_url_http}", LogColor.BLUE)
+        self._log.info(f"config.base_url_ws={config.base_url_ws}", LogColor.BLUE)
+        self._log.info(f"config.venue={config.venue}", LogColor.BLUE)
+        self._log.info(f"config.product={config.product}", LogColor.BLUE)
+
+    async def _connect(self) -> None:
+        self._log.info("Connecting to OpenAlgo...", LogColor.BLUE)
+        await self._client.connect()
+        await self._instrument_provider.initialize()
+        self._log.info("OpenAlgo execution client connected", LogColor.GREEN)
+
+    async def _disconnect(self) -> None:
+        await self._client.close()
+        self._log.info("OpenAlgo execution client disconnected", LogColor.GREEN)
+
+    async def _submit_order(self, command: SubmitOrder) -> None:
+        order = command.order
+        if order.is_closed:
+            self._log.warning(f"Order {order} is already closed")
+            return
+
+        self.generate_order_submitted(
+            strategy_id=order.strategy_id,
+            instrument_id=order.instrument_id,
+            client_order_id=order.client_order_id,
+            ts_event=self._clock.timestamp_ns(),
+        )
+
+        try:
+            response = await self._client.place_order(
+                strategy=self._strategy_name(order),
+                symbol=self._symbol(order.instrument_id),
+                action=self._action(order.side),
+                exchange=self._exchange(order.instrument_id),
+                pricetype=self._price_type(order.order_type),
+                product=self._product(order),
+                quantity=self._quantity(order.quantity),
+                price=self._price(order.price if order.has_price else None),
+                trigger_price=self._price(
+                    order.trigger_price if order.has_trigger_price else None,
+                ),
+            )
+            venue_order_id = VenueOrderId(str(response["orderid"]))
+            self.generate_order_accepted(
+                strategy_id=order.strategy_id,
+                instrument_id=order.instrument_id,
+                client_order_id=order.client_order_id,
+                venue_order_id=venue_order_id,
+                ts_event=self._clock.timestamp_ns(),
+            )
+        except Exception as e:
+            self._log.error(f"Error submitting order {order.client_order_id}: {e}")
+            self.generate_order_rejected(
+                strategy_id=order.strategy_id,
+                instrument_id=order.instrument_id,
+                client_order_id=order.client_order_id,
+                reason=str(e),
+                ts_event=self._clock.timestamp_ns(),
+            )
+
+    async def _submit_order_list(self, command: SubmitOrderList) -> None:
+        for order in command.order_list.orders:
+            await self._submit_order(
+                SubmitOrder(
+                    trader_id=command.trader_id,
+                    strategy_id=command.strategy_id,
+                    order=order,
+                    command_id=command.id,
+                    ts_init=command.ts_init,
+                    client_id=command.client_id,
+                    position_id=command.position_id,
+                    params=command.params,
+                ),
+            )
+
+    async def _modify_order(self, command: ModifyOrder) -> None:
+        order = self._cache.order(command.client_order_id)
+        venue_order_id = command.venue_order_id or self._cache.venue_order_id(
+            command.client_order_id,
+        )
+        if order is None or venue_order_id is None:
+            self.generate_order_modify_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=venue_order_id or VenueOrderId("UNKNOWN"),
+                reason="Missing cached order or venue_order_id",
+                ts_event=self._clock.timestamp_ns(),
+            )
+            return
+
+        quantity = command.quantity or order.quantity
+        price = command.price or (order.price if order.has_price else None)
+        trigger_price = command.trigger_price or (
+            order.trigger_price if order.has_trigger_price else None
+        )
+
+        try:
+            await self._client.modify_order(
+                strategy=self._strategy_name(order),
+                orderid=venue_order_id.value,
+                symbol=self._symbol(command.instrument_id),
+                action=self._action(order.side),
+                exchange=self._exchange(command.instrument_id),
+                pricetype=self._price_type(order.order_type),
+                product=self._product(order),
+                quantity=self._quantity(quantity),
+                price=self._price(price),
+                trigger_price=self._price(trigger_price),
+            )
+            self.generate_order_updated(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=venue_order_id,
+                quantity=quantity,
+                price=price,
+                trigger_price=trigger_price,
+                ts_event=self._clock.timestamp_ns(),
+            )
+        except Exception as e:
+            self._log.error(f"Error modifying order {command.client_order_id}: {e}")
+            self.generate_order_modify_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=venue_order_id,
+                reason=str(e),
+                ts_event=self._clock.timestamp_ns(),
+            )
+
+    async def _cancel_order(self, command: CancelOrder) -> None:
+        venue_order_id = command.venue_order_id or self._cache.venue_order_id(
+            command.client_order_id,
+        )
+        if venue_order_id is None:
+            self.generate_order_cancel_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=VenueOrderId("UNKNOWN"),
+                reason="Missing venue_order_id",
+                ts_event=self._clock.timestamp_ns(),
+            )
+            return
+
+        try:
+            await self._client.cancel_order(
+                strategy=self._config.strategy,
+                orderid=venue_order_id.value,
+            )
+            self.generate_order_canceled(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=venue_order_id,
+                ts_event=self._clock.timestamp_ns(),
+            )
+        except Exception as e:
+            self._log.error(f"Error canceling order {command.client_order_id}: {e}")
+            self.generate_order_cancel_rejected(
+                strategy_id=command.strategy_id,
+                instrument_id=command.instrument_id,
+                client_order_id=command.client_order_id,
+                venue_order_id=venue_order_id,
+                reason=str(e),
+                ts_event=self._clock.timestamp_ns(),
+            )
+
+    async def _cancel_all_orders(self, command: CancelAllOrders) -> None:
+        try:
+            await self._client.cancel_all_order(strategy=self._config.strategy)
+        except Exception as e:
+            self._log.error(f"Error canceling all orders: {e}")
+
+    async def _batch_cancel_orders(self, command: BatchCancelOrders) -> None:
+        for cancel in command.cancels:
+            await self._cancel_order(cancel)
+
+    async def generate_order_status_report(
+        self,
+        command: GenerateOrderStatusReport,
+    ) -> OrderStatusReport | None:
+        venue_order_id = command.venue_order_id
+        if venue_order_id is None and command.client_order_id is not None:
+            venue_order_id = self._cache.venue_order_id(command.client_order_id)
+        if venue_order_id is None:
+            self._log.warning("Cannot query OpenAlgo order status without venue_order_id")
+            return None
+
+        response = await self._client.order_status(
+            strategy=self._config.strategy,
+            orderid=venue_order_id.value,
+        )
+        data = response.get("data") or {}
+        return self._parse_order_status_report(
+            data=data,
+            client_order_id=command.client_order_id,
+            instrument_id=command.instrument_id,
+        )
+
+    async def generate_order_status_reports(
+        self,
+        command: GenerateOrderStatusReports,
+    ) -> list[OrderStatusReport]:
+        response = await self._client.orderbook()
+        orders = (response.get("data") or {}).get("orders") or []
+        reports = [
+            report
+            for item in orders
+            if (report := self._parse_order_status_report(item, None, command.instrument_id))
+            is not None
+        ]
+        self._log_report_receipt(
+            len(reports),
+            "OrderStatusReport",
+            command.log_receipt_level,
+            "Generated",
+        )
+        return reports
+
+    async def generate_fill_reports(
+        self,
+        command: GenerateFillReports,
+    ) -> list[FillReport]:
+        response = await self._client.tradebook()
+        trades = response.get("data") or []
+        reports = [
+            report
+            for item in trades
+            if (report := self._parse_fill_report(item, command.instrument_id)) is not None
+        ]
+        self._log_report_receipt(len(reports), "FillReport", command.log_receipt_level, "Generated")
+        return reports
+
+    async def generate_position_status_reports(
+        self,
+        command: GeneratePositionStatusReports,
+    ) -> list[PositionStatusReport]:
+        response = await self._client.positionbook()
+        positions = response.get("data") or []
+        reports = [
+            report
+            for item in positions
+            if (report := self._parse_position_status_report(item, command.instrument_id))
+            is not None
+        ]
+        self._log_report_receipt(
+            len(reports),
+            "PositionStatusReport",
+            command.log_receipt_level,
+            "Generated",
+        )
+        return reports
+
+    async def _query_account(self, command: QueryAccount) -> None:
+        response = await self._client.funds()
+        self._log.info(f"OpenAlgo funds response: {response.get('data')}")
+
+    def _parse_order_status_report(
+        self,
+        data: dict[str, Any],
+        client_order_id: Any | None,
+        instrument_id: InstrumentId | None,
+    ) -> OrderStatusReport | None:
+        if not data:
+            return None
+
+        instrument_id = instrument_id or self._instrument_id(data)
+        if instrument_id is None:
+            return None
+
+        order_status = self._order_status(data.get("order_status"))
+        quantity = self._make_qty(instrument_id, data.get("quantity", "0"))
+        filled_qty = quantity if order_status == OrderStatus.FILLED else Quantity.zero(
+            quantity.precision,
+        )
+        ts_last = self._timestamp_ns(data.get("timestamp"))
+
+        return OrderStatusReport(
+            account_id=self.account_id,
+            instrument_id=instrument_id,
+            client_order_id=client_order_id,
+            order_list_id=None,
+            venue_order_id=VenueOrderId(str(data["orderid"])),
+            order_side=self._order_side(data.get("action")),
+            order_type=self._order_type(data.get("pricetype")),
+            time_in_force=TimeInForce.DAY,
+            order_status=order_status,
+            price=self._make_price_or_none(instrument_id, data.get("price")),
+            trigger_price=self._make_price_or_none(instrument_id, data.get("trigger_price")),
+            quantity=quantity,
+            filled_qty=filled_qty,
+            avg_px=self._decimal_or_none(data.get("average_price")),
+            ts_accepted=ts_last,
+            ts_last=ts_last,
+            report_id=UUID4(),
+            ts_init=self._clock.timestamp_ns(),
+        )
+
+    def _parse_fill_report(
+        self,
+        data: dict[str, Any],
+        instrument_id: InstrumentId | None,
+    ) -> FillReport | None:
+        instrument_id = instrument_id or self._instrument_id(data)
+        if instrument_id is None:
+            return None
+
+        ts_event = self._timestamp_ns(data.get("timestamp"))
+        return FillReport(
+            account_id=self.account_id,
+            instrument_id=instrument_id,
+            client_order_id=None,
+            venue_order_id=VenueOrderId(str(data["orderid"])),
+            trade_id=TradeId(f"{data['orderid']}-{ts_event}"),
+            order_side=self._order_side(data.get("action")),
+            last_qty=self._make_qty(instrument_id, data.get("quantity", "0")),
+            last_px=self._make_price(instrument_id, data.get("average_price", "0")),
+            commission=Money(0, self._base_currency),
+            liquidity_side=LiquiditySide.NO_LIQUIDITY_SIDE,
+            report_id=UUID4(),
+            ts_event=ts_event,
+            ts_init=self._clock.timestamp_ns(),
+        )
+
+    def _parse_position_status_report(
+        self,
+        data: dict[str, Any],
+        instrument_id: InstrumentId | None,
+    ) -> PositionStatusReport | None:
+        instrument_id = instrument_id or self._instrument_id(data)
+        if instrument_id is None:
+            return None
+
+        raw_qty = Decimal(str(data.get("quantity", "0")))
+        side = PositionSide.FLAT
+        if raw_qty > 0:
+            side = PositionSide.LONG
+        elif raw_qty < 0:
+            side = PositionSide.SHORT
+
+        return PositionStatusReport(
+            account_id=self.account_id,
+            instrument_id=instrument_id,
+            position_side=side,
+            quantity=self._make_qty(instrument_id, abs(raw_qty)),
+            avg_px_open=self._decimal_or_none(data.get("average_price")),
+            report_id=UUID4(),
+            ts_last=self._clock.timestamp_ns(),
+            ts_init=self._clock.timestamp_ns(),
+        )
+
+    def _instrument_id(self, data: dict[str, Any]) -> InstrumentId | None:
+        symbol = data.get("symbol")
+        exchange = data.get("exchange") or self._config.venue
+        if not symbol:
+            return None
+        return InstrumentId.from_str(f"{symbol}.{exchange}")
+
+    def _symbol(self, instrument_id: InstrumentId) -> str:
+        return instrument_id.symbol.value
+
+    def _exchange(self, instrument_id: InstrumentId) -> str:
+        return instrument_id.venue.value
+
+    def _strategy_name(self, order: Order) -> str:
+        params = order.params or {}
+        return str(params.get("strategy", self._config.strategy))
+
+    def _product(self, order: Order) -> str:
+        params = order.params or {}
+        return str(params.get("product", self._config.product))
+
+    def _quantity(self, quantity: Quantity) -> str:
+        return quantity.to_formatted_str()
+
+    def _price(self, price: Price | None) -> str:
+        return price.to_formatted_str() if price is not None else "0"
+
+    def _action(self, side: OrderSide) -> str:
+        if side == OrderSide.BUY:
+            return "BUY"
+        if side == OrderSide.SELL:
+            return "SELL"
+        raise ValueError(f"Unsupported OpenAlgo order side: {side}")
+
+    def _price_type(self, order_type: OrderType) -> str:
+        if order_type == OrderType.MARKET:
+            return "MARKET"
+        if order_type == OrderType.LIMIT:
+            return "LIMIT"
+        if order_type == OrderType.STOP_MARKET:
+            return "SL-M"
+        if order_type == OrderType.STOP_LIMIT:
+            return "SL"
+        raise ValueError(f"Unsupported OpenAlgo order type: {order_type}")
+
+    def _order_side(self, value: Any) -> OrderSide:
+        return OrderSide.BUY if str(value).upper() == "BUY" else OrderSide.SELL
+
+    def _order_type(self, value: Any) -> OrderType:
+        value = str(value).upper()
+        if value == "LIMIT":
+            return OrderType.LIMIT
+        if value == "SL":
+            return OrderType.STOP_LIMIT
+        if value == "SL-M":
+            return OrderType.STOP_MARKET
+        return OrderType.MARKET
+
+    def _order_status(self, value: Any) -> OrderStatus:
+        value = str(value).lower()
+        if value in {"complete", "completed", "filled"}:
+            return OrderStatus.FILLED
+        if value in {"cancelled", "canceled"}:
+            return OrderStatus.CANCELED
+        if value in {"rejected", "reject"}:
+            return OrderStatus.REJECTED
+        if value in {"trigger pending", "trigger_pending"}:
+            return OrderStatus.TRIGGERED
+        return OrderStatus.ACCEPTED
+
+    def _make_qty(self, instrument_id: InstrumentId, value: Any) -> Quantity:
+        instrument = self._cache.instrument(instrument_id) or self._instrument_provider.find(
+            instrument_id,
+        )
+        if instrument is not None:
+            return instrument.make_qty(value)
+        return Quantity.from_str(str(value))
+
+    def _make_price(self, instrument_id: InstrumentId, value: Any) -> Price:
+        instrument = self._cache.instrument(instrument_id) or self._instrument_provider.find(
+            instrument_id,
+        )
+        if instrument is not None:
+            return instrument.make_price(value)
+        return Price.from_str(str(value))
+
+    def _make_price_or_none(self, instrument_id: InstrumentId, value: Any) -> Price | None:
+        decimal = self._decimal_or_none(value)
+        if decimal is None or decimal == 0:
+            return None
+        return self._make_price(instrument_id, decimal)
+
+    def _decimal_or_none(self, value: Any) -> Decimal | None:
+        if value is None or value == "":
+            return None
+        return Decimal(str(value))
+
+    def _timestamp_ns(self, value: Any) -> int:
+        if not value:
+            return self._clock.timestamp_ns()
+        try:
+            dt = datetime.strptime(str(value), "%d-%b-%Y %H:%M:%S")
+            return int(dt.timestamp() * 1_000_000_000)
+        except ValueError:
+            return self._clock.timestamp_ns()

--- a/nautilus_trader/adapters/openalgo/factories.py
+++ b/nautilus_trader/adapters/openalgo/factories.py
@@ -1,0 +1,93 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import asyncio
+from functools import lru_cache
+
+from nautilus_trader.adapters.openalgo.config import OpenAlgoExecClientConfig
+from nautilus_trader.adapters.openalgo.execution import OpenAlgoExecutionClient
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpClient
+from nautilus_trader.adapters.openalgo.providers import OpenAlgoInstrumentProvider
+from nautilus_trader.cache.cache import Cache
+from nautilus_trader.common.component import LiveClock
+from nautilus_trader.common.component import MessageBus
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.live.factories import LiveExecClientFactory
+
+
+@lru_cache(1)
+def get_cached_openalgo_http_client(
+    api_key: str | None = None,
+    base_url: str = "http://127.0.0.1:5000",
+    api_version: str = "v1",
+    timeout_secs: int = 10,
+    proxy_url: str | None = None,
+) -> OpenAlgoHttpClient:
+    """
+    Cache and return an OpenAlgo HTTP client.
+    """
+    return OpenAlgoHttpClient(
+        api_key=api_key,
+        base_url=base_url,
+        api_version=api_version,
+        timeout_secs=timeout_secs,
+        proxy_url=proxy_url,
+    )
+
+
+@lru_cache(1)
+def get_cached_openalgo_instrument_provider(
+    config: InstrumentProviderConfig | None = None,
+) -> OpenAlgoInstrumentProvider:
+    """
+    Cache and return an OpenAlgo instrument provider.
+    """
+    return OpenAlgoInstrumentProvider(config=config)
+
+
+class OpenAlgoLiveExecClientFactory(LiveExecClientFactory):
+    """
+    Provides an OpenAlgo live execution client factory.
+    """
+
+    @staticmethod
+    def create(  # type: ignore
+        loop: asyncio.AbstractEventLoop,
+        name: str,
+        config: OpenAlgoExecClientConfig,
+        msgbus: MessageBus,
+        cache: Cache,
+        clock: LiveClock,
+    ) -> OpenAlgoExecutionClient:
+        client = get_cached_openalgo_http_client(
+            api_key=config.api_key,
+            base_url=config.base_url_http,
+            api_version=config.api_version,
+            timeout_secs=config.http_timeout_secs,
+            proxy_url=config.http_proxy_url,
+        )
+        provider = get_cached_openalgo_instrument_provider(config=config.instrument_provider)
+        return OpenAlgoExecutionClient(
+            loop=loop,
+            client=client,
+            msgbus=msgbus,
+            cache=cache,
+            clock=clock,
+            instrument_provider=provider,
+            config=config,
+            name=name,
+        )

--- a/nautilus_trader/adapters/openalgo/factories.py
+++ b/nautilus_trader/adapters/openalgo/factories.py
@@ -34,6 +34,7 @@ def get_cached_openalgo_http_client(
     api_key: str | None = None,
     base_url: str = "http://127.0.0.1:5000",
     api_version: str = "v1",
+    ws_url: str = "ws://127.0.0.1:8765",
     timeout_secs: int = 10,
     proxy_url: str | None = None,
 ) -> OpenAlgoHttpClient:
@@ -44,6 +45,7 @@ def get_cached_openalgo_http_client(
         api_key=api_key,
         base_url=base_url,
         api_version=api_version,
+        ws_url=ws_url,
         timeout_secs=timeout_secs,
         proxy_url=proxy_url,
     )
@@ -77,6 +79,7 @@ class OpenAlgoLiveExecClientFactory(LiveExecClientFactory):
             api_key=config.api_key,
             base_url=config.base_url_http,
             api_version=config.api_version,
+            ws_url=config.base_url_ws,
             timeout_secs=config.http_timeout_secs,
             proxy_url=config.http_proxy_url,
         )

--- a/nautilus_trader/adapters/openalgo/http/__init__.py
+++ b/nautilus_trader/adapters/openalgo/http/__init__.py
@@ -1,0 +1,23 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpClient
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpError
+
+
+__all__ = [
+    "OpenAlgoHttpClient",
+    "OpenAlgoHttpError",
+]

--- a/nautilus_trader/adapters/openalgo/http/client.py
+++ b/nautilus_trader/adapters/openalgo/http/client.py
@@ -41,13 +41,18 @@ class OpenAlgoHttpClient:
         timeout_secs: int = 10,
         proxy_url: str | None = None,
     ) -> None:
+        if timeout_secs != 10 or proxy_url is not None:
+            raise ValueError(
+                "timeout_secs/proxy_url are not supported by the OpenAlgo Rust SDK client yet",
+            )
+
         self._client = RustOpenAlgoHttpClient(
             api_key,
             base_url,
             api_version,
             ws_url,
-            timeout_secs,
-            proxy_url,
+            None,
+            None,
         )
 
     async def connect(self) -> None:

--- a/nautilus_trader/adapters/openalgo/http/client.py
+++ b/nautilus_trader/adapters/openalgo/http/client.py
@@ -1,0 +1,176 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import aiohttp
+
+
+class OpenAlgoHttpError(RuntimeError):
+    """
+    Raised when the OpenAlgo HTTP API returns an error response.
+    """
+
+
+class OpenAlgoHttpClient:
+    """
+    Thin async client for OpenAlgo's local REST API.
+    """
+
+    def __init__(
+        self,
+        api_key: str | None = None,
+        base_url: str = "http://127.0.0.1:5000",
+        api_version: str = "v1",
+        timeout_secs: int = 10,
+        proxy_url: str | None = None,
+        session: aiohttp.ClientSession | None = None,
+    ) -> None:
+        self._api_key = api_key or os.getenv("OPENALGO_API_KEY")
+        if not self._api_key:
+            raise ValueError("OpenAlgo API key not provided; set api_key or OPENALGO_API_KEY")
+
+        self._base_url = base_url.rstrip("/")
+        self._api_version = api_version.strip("/")
+        self._timeout = aiohttp.ClientTimeout(total=timeout_secs)
+        self._proxy_url = proxy_url
+        self._session = session
+        self._owns_session = session is None
+
+    async def connect(self) -> None:
+        if self._session is None or self._session.closed:
+            self._session = aiohttp.ClientSession(timeout=self._timeout)
+
+    async def close(self) -> None:
+        if self._owns_session and self._session is not None and not self._session.closed:
+            await self._session.close()
+
+    async def ping(self) -> dict[str, Any]:
+        return await self._post("ping")
+
+    async def funds(self) -> dict[str, Any]:
+        return await self._post("funds")
+
+    async def orderbook(self) -> dict[str, Any]:
+        return await self._post("orderbook")
+
+    async def tradebook(self) -> dict[str, Any]:
+        return await self._post("tradebook")
+
+    async def positionbook(self) -> dict[str, Any]:
+        return await self._post("positionbook")
+
+    async def place_order(
+        self,
+        *,
+        strategy: str,
+        symbol: str,
+        action: str,
+        exchange: str,
+        pricetype: str,
+        product: str,
+        quantity: str,
+        price: str = "0",
+        trigger_price: str = "0",
+        disclosed_quantity: str = "0",
+    ) -> dict[str, Any]:
+        return await self._post(
+            "placeorder",
+            {
+                "strategy": strategy,
+                "symbol": symbol,
+                "action": action,
+                "exchange": exchange,
+                "pricetype": pricetype,
+                "product": product,
+                "quantity": quantity,
+                "price": price,
+                "trigger_price": trigger_price,
+                "disclosed_quantity": disclosed_quantity,
+            },
+        )
+
+    async def modify_order(
+        self,
+        *,
+        strategy: str,
+        orderid: str,
+        symbol: str,
+        action: str,
+        exchange: str,
+        pricetype: str,
+        product: str,
+        quantity: str,
+        price: str = "0",
+        trigger_price: str = "0",
+        disclosed_quantity: str = "0",
+    ) -> dict[str, Any]:
+        return await self._post(
+            "modifyorder",
+            {
+                "strategy": strategy,
+                "orderid": orderid,
+                "symbol": symbol,
+                "action": action,
+                "exchange": exchange,
+                "pricetype": pricetype,
+                "product": product,
+                "quantity": quantity,
+                "price": price,
+                "trigger_price": trigger_price,
+                "disclosed_quantity": disclosed_quantity,
+            },
+        )
+
+    async def cancel_order(self, *, strategy: str, orderid: str) -> dict[str, Any]:
+        return await self._post("cancelorder", {"strategy": strategy, "orderid": orderid})
+
+    async def cancel_all_order(self, *, strategy: str) -> dict[str, Any]:
+        return await self._post("cancelallorder", {"strategy": strategy})
+
+    async def order_status(self, *, strategy: str, orderid: str) -> dict[str, Any]:
+        return await self._post("orderstatus", {"strategy": strategy, "orderid": orderid})
+
+    async def _post(
+        self,
+        endpoint: str,
+        payload: dict[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        await self.connect()
+        assert self._session is not None
+
+        url = f"{self._base_url}/api/{self._api_version}/{endpoint}"
+        body = {"apikey": self._api_key}
+        if payload:
+            body.update(payload)
+
+        async with self._session.post(url, json=body, proxy=self._proxy_url) as resp:
+            try:
+                data = await resp.json(content_type=None)
+            except Exception as e:
+                text = await resp.text()
+                raise OpenAlgoHttpError(
+                    f"OpenAlgo {endpoint} returned non-JSON HTTP {resp.status}: {text}",
+                ) from e
+
+        status = str(data.get("status", "")).lower()
+        if resp.status >= 400 or status in {"error", "failure", "failed"}:
+            message = data.get("message") or data.get("error") or data
+            raise OpenAlgoHttpError(f"OpenAlgo {endpoint} failed: {message}")
+
+        return data

--- a/nautilus_trader/adapters/openalgo/http/client.py
+++ b/nautilus_trader/adapters/openalgo/http/client.py
@@ -87,6 +87,8 @@ class OpenAlgoHttpClient:
         trigger_price: str = "0",
         disclosed_quantity: str = "0",
     ) -> dict[str, Any]:
+        if disclosed_quantity not in {"0", ""}:
+            raise ValueError("disclosed_quantity is not supported by OpenAlgo Rust SDK v1.0.5")
         del disclosed_quantity  # OpenAlgo Rust SDK v1.0.5 does not expose this optional field.
         return self._decode(
             await self._client.place_order(

--- a/nautilus_trader/adapters/openalgo/http/client.py
+++ b/nautilus_trader/adapters/openalgo/http/client.py
@@ -15,10 +15,10 @@
 
 from __future__ import annotations
 
-import os
+import json
 from typing import Any
 
-import aiohttp
+from nautilus_trader._libnautilus.openalgo import OpenAlgoHttpClient as RustOpenAlgoHttpClient
 
 
 class OpenAlgoHttpError(RuntimeError):
@@ -29,7 +29,7 @@ class OpenAlgoHttpError(RuntimeError):
 
 class OpenAlgoHttpClient:
     """
-    Thin async client for OpenAlgo's local REST API.
+    Thin Python compatibility wrapper around the Rust OpenAlgo SDK client.
     """
 
     def __init__(
@@ -37,43 +37,36 @@ class OpenAlgoHttpClient:
         api_key: str | None = None,
         base_url: str = "http://127.0.0.1:5000",
         api_version: str = "v1",
+        ws_url: str = "ws://127.0.0.1:8765",
         timeout_secs: int = 10,
         proxy_url: str | None = None,
-        session: aiohttp.ClientSession | None = None,
     ) -> None:
-        self._api_key = api_key or os.getenv("OPENALGO_API_KEY")
-        if not self._api_key:
-            raise ValueError("OpenAlgo API key not provided; set api_key or OPENALGO_API_KEY")
-
-        self._base_url = base_url.rstrip("/")
-        self._api_version = api_version.strip("/")
-        self._timeout = aiohttp.ClientTimeout(total=timeout_secs)
-        self._proxy_url = proxy_url
-        self._session = session
-        self._owns_session = session is None
+        self._client = RustOpenAlgoHttpClient(
+            api_key,
+            base_url,
+            api_version,
+            ws_url,
+            timeout_secs,
+            proxy_url,
+        )
 
     async def connect(self) -> None:
-        if self._session is None or self._session.closed:
-            self._session = aiohttp.ClientSession(timeout=self._timeout)
+        await self._client.connect()
 
     async def close(self) -> None:
-        if self._owns_session and self._session is not None and not self._session.closed:
-            await self._session.close()
-
-    async def ping(self) -> dict[str, Any]:
-        return await self._post("ping")
+        await self._client.close()
 
     async def funds(self) -> dict[str, Any]:
-        return await self._post("funds")
+        return self._decode(await self._client.funds())
 
     async def orderbook(self) -> dict[str, Any]:
-        return await self._post("orderbook")
+        return self._decode(await self._client.orderbook())
 
     async def tradebook(self) -> dict[str, Any]:
-        return await self._post("tradebook")
+        return self._decode(await self._client.tradebook())
 
     async def positionbook(self) -> dict[str, Any]:
-        return await self._post("positionbook")
+        return self._decode(await self._client.positionbook())
 
     async def place_order(
         self,
@@ -89,20 +82,19 @@ class OpenAlgoHttpClient:
         trigger_price: str = "0",
         disclosed_quantity: str = "0",
     ) -> dict[str, Any]:
-        return await self._post(
-            "placeorder",
-            {
-                "strategy": strategy,
-                "symbol": symbol,
-                "action": action,
-                "exchange": exchange,
-                "pricetype": pricetype,
-                "product": product,
-                "quantity": quantity,
-                "price": price,
-                "trigger_price": trigger_price,
-                "disclosed_quantity": disclosed_quantity,
-            },
+        del disclosed_quantity  # OpenAlgo Rust SDK v1.0.5 does not expose this optional field.
+        return self._decode(
+            await self._client.place_order(
+                strategy,
+                symbol,
+                action,
+                exchange,
+                pricetype,
+                product,
+                quantity,
+                price,
+                trigger_price,
+            ),
         )
 
     async def modify_order(
@@ -120,57 +112,34 @@ class OpenAlgoHttpClient:
         trigger_price: str = "0",
         disclosed_quantity: str = "0",
     ) -> dict[str, Any]:
-        return await self._post(
-            "modifyorder",
-            {
-                "strategy": strategy,
-                "orderid": orderid,
-                "symbol": symbol,
-                "action": action,
-                "exchange": exchange,
-                "pricetype": pricetype,
-                "product": product,
-                "quantity": quantity,
-                "price": price,
-                "trigger_price": trigger_price,
-                "disclosed_quantity": disclosed_quantity,
-            },
+        del trigger_price, disclosed_quantity
+        return self._decode(
+            await self._client.modify_order(
+                orderid,
+                strategy,
+                symbol,
+                action,
+                exchange,
+                pricetype,
+                product,
+                quantity,
+                price,
+            ),
         )
 
     async def cancel_order(self, *, strategy: str, orderid: str) -> dict[str, Any]:
-        return await self._post("cancelorder", {"strategy": strategy, "orderid": orderid})
+        return self._decode(await self._client.cancel_order(orderid, strategy))
 
     async def cancel_all_order(self, *, strategy: str) -> dict[str, Any]:
-        return await self._post("cancelallorder", {"strategy": strategy})
+        return self._decode(await self._client.cancel_all_order(strategy))
 
     async def order_status(self, *, strategy: str, orderid: str) -> dict[str, Any]:
-        return await self._post("orderstatus", {"strategy": strategy, "orderid": orderid})
+        return self._decode(await self._client.order_status(orderid, strategy))
 
-    async def _post(
-        self,
-        endpoint: str,
-        payload: dict[str, Any] | None = None,
-    ) -> dict[str, Any]:
-        await self.connect()
-        assert self._session is not None
-
-        url = f"{self._base_url}/api/{self._api_version}/{endpoint}"
-        body = {"apikey": self._api_key}
-        if payload:
-            body.update(payload)
-
-        async with self._session.post(url, json=body, proxy=self._proxy_url) as resp:
-            try:
-                data = await resp.json(content_type=None)
-            except Exception as e:
-                text = await resp.text()
-                raise OpenAlgoHttpError(
-                    f"OpenAlgo {endpoint} returned non-JSON HTTP {resp.status}: {text}",
-                ) from e
-
+    def _decode(self, raw: str) -> dict[str, Any]:
+        data = json.loads(raw)
         status = str(data.get("status", "")).lower()
-        if resp.status >= 400 or status in {"error", "failure", "failed"}:
+        if status in {"error", "failure", "failed"}:
             message = data.get("message") or data.get("error") or data
-            raise OpenAlgoHttpError(f"OpenAlgo {endpoint} failed: {message}")
-
+            raise OpenAlgoHttpError(f"OpenAlgo request failed: {message}")
         return data

--- a/nautilus_trader/adapters/openalgo/http/client.py
+++ b/nautilus_trader/adapters/openalgo/http/client.py
@@ -119,6 +119,10 @@ class OpenAlgoHttpClient:
         trigger_price: str = "0",
         disclosed_quantity: str = "0",
     ) -> dict[str, Any]:
+        if trigger_price not in {"0", ""}:
+            raise ValueError("trigger_price is not supported by OpenAlgo Rust SDK v1.0.5")
+        if disclosed_quantity not in {"0", ""}:
+            raise ValueError("disclosed_quantity is not supported by OpenAlgo Rust SDK v1.0.5")
         del trigger_price, disclosed_quantity
         return self._decode(
             await self._client.modify_order(

--- a/nautilus_trader/adapters/openalgo/providers.py
+++ b/nautilus_trader/adapters/openalgo/providers.py
@@ -1,0 +1,55 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from nautilus_trader.common.providers import InstrumentProvider
+from nautilus_trader.config import InstrumentProviderConfig
+from nautilus_trader.model.identifiers import InstrumentId
+
+
+class OpenAlgoInstrumentProvider(InstrumentProvider):
+    """
+    Minimal OpenAlgo instrument provider.
+
+    OpenAlgo routes to broker symbols supplied by the user, so this provider does not
+    currently discover instruments. Strategies should load/cache Nautilus instruments
+    separately, or use simple IDs such as ``RELIANCE.NSE``.
+    """
+
+    def __init__(self, config: InstrumentProviderConfig | None = None) -> None:
+        super().__init__(config=config or InstrumentProviderConfig())
+
+    async def load_all_async(self, filters: dict | None = None) -> None:
+        self._log.warning("OpenAlgo instrument discovery is not available; loaded 0 instruments")
+
+    async def load_ids_async(
+        self,
+        instrument_ids: list[InstrumentId],
+        filters: dict | None = None,
+    ) -> None:
+        self._log.warning(
+            "OpenAlgo instrument discovery is not available; "
+            f"unable to load {len(instrument_ids)} instruments",
+        )
+
+    async def load_async(
+        self,
+        instrument_id: InstrumentId,
+        filters: dict | None = None,
+    ) -> None:
+        self._log.warning(
+            f"OpenAlgo instrument discovery is not available; unable to load {instrument_id}",
+        )

--- a/python/nautilus_trader/adapters/openalgo/__init__.py
+++ b/python/nautilus_trader/adapters/openalgo/__init__.py
@@ -13,17 +13,4 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-from __future__ import annotations
-
-from typing import Final
-
-from nautilus_trader.model.identifiers import ClientId
-
-
-OPENALGO: Final[str] = "OPENALGO"
-OPENALGO_CLIENT_ID: Final[ClientId] = ClientId(OPENALGO)
-OPENALGO_DEFAULT_BASE_URL: Final[str] = "http://127.0.0.1:5000"
-OPENALGO_DEFAULT_WS_URL: Final[str] = "ws://127.0.0.1:8765"
-OPENALGO_DEFAULT_API_VERSION: Final[str] = "v1"
-OPENALGO_DEFAULT_VENUE: Final[str] = "NSE"
-OPENALGO_DEFAULT_API_KEY: Final[str] = ""
+from nautilus_trader._libnautilus.openalgo import *  # noqa: F403 (undefined-local-with-import-star)

--- a/python/nautilus_trader/adapters/openalgo/__init__.pyi
+++ b/python/nautilus_trader/adapters/openalgo/__init__.pyi
@@ -13,17 +13,4 @@
 #  limitations under the License.
 # -------------------------------------------------------------------------------------------------
 
-from __future__ import annotations
-
-from typing import Final
-
-from nautilus_trader.model.identifiers import ClientId
-
-
-OPENALGO: Final[str] = "OPENALGO"
-OPENALGO_CLIENT_ID: Final[ClientId] = ClientId(OPENALGO)
-OPENALGO_DEFAULT_BASE_URL: Final[str] = "http://127.0.0.1:5000"
-OPENALGO_DEFAULT_WS_URL: Final[str] = "ws://127.0.0.1:8765"
-OPENALGO_DEFAULT_API_VERSION: Final[str] = "v1"
-OPENALGO_DEFAULT_VENUE: Final[str] = "NSE"
-OPENALGO_DEFAULT_API_KEY: Final[str] = ""
+from nautilus_trader._libnautilus.openalgo import *  # noqa: F403 (undefined-local-with-import-star)

--- a/tests/integration_tests/adapters/openalgo/test_http_client.py
+++ b/tests/integration_tests/adapters/openalgo/test_http_client.py
@@ -1,0 +1,79 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+from aiohttp import web
+
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpClient
+from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpError
+
+
+@pytest.mark.asyncio
+async def test_place_order_posts_openalgo_payload(aiohttp_server):
+    received = {}
+
+    async def handler(request):
+        received.update(await request.json())
+        return web.json_response({"status": "success", "orderid": "250408000989443"})
+
+    app = web.Application()
+    app.router.add_post("/api/v1/placeorder", handler)
+    server = await aiohttp_server(app)
+
+    client = OpenAlgoHttpClient(api_key="KEY", base_url=str(server.make_url("")))
+    try:
+        response = await client.place_order(
+            strategy="NautilusTrader",
+            symbol="RELIANCE",
+            action="BUY",
+            exchange="NSE",
+            pricetype="MARKET",
+            product="MIS",
+            quantity="1",
+        )
+    finally:
+        await client.close()
+
+    assert response == {"status": "success", "orderid": "250408000989443"}
+    assert received == {
+        "apikey": "KEY",
+        "strategy": "NautilusTrader",
+        "symbol": "RELIANCE",
+        "action": "BUY",
+        "exchange": "NSE",
+        "pricetype": "MARKET",
+        "product": "MIS",
+        "quantity": "1",
+        "price": "0",
+        "trigger_price": "0",
+        "disclosed_quantity": "0",
+    }
+
+
+@pytest.mark.asyncio
+async def test_error_status_raises(aiohttp_server):
+    async def handler(request):
+        return web.json_response({"status": "error", "message": "bad order"})
+
+    app = web.Application()
+    app.router.add_post("/api/v1/cancelorder", handler)
+    server = await aiohttp_server(app)
+
+    client = OpenAlgoHttpClient(api_key="KEY", base_url=str(server.make_url("")))
+    try:
+        with pytest.raises(OpenAlgoHttpError, match="bad order"):
+            await client.cancel_order(strategy="NautilusTrader", orderid="1")
+    finally:
+        await client.close()

--- a/tests/integration_tests/adapters/openalgo/test_http_client.py
+++ b/tests/integration_tests/adapters/openalgo/test_http_client.py
@@ -21,7 +21,7 @@ from nautilus_trader.adapters.openalgo.http.client import OpenAlgoHttpError
 
 
 @pytest.mark.asyncio
-async def test_place_order_posts_openalgo_payload(aiohttp_server):
+async def test_place_order_posts_openalgo_sdk_payload(aiohttp_server):
     received = {}
 
     async def handler(request):
@@ -56,9 +56,6 @@ async def test_place_order_posts_openalgo_payload(aiohttp_server):
         "pricetype": "MARKET",
         "product": "MIS",
         "quantity": "1",
-        "price": "0",
-        "trigger_price": "0",
-        "disclosed_quantity": "0",
     }
 
 

--- a/tests/unit_tests/adapters/test_env.py
+++ b/tests/unit_tests/adapters/test_env.py
@@ -1,0 +1,85 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+import pytest
+
+from nautilus_trader.adapters.env import get_env_key
+from nautilus_trader.adapters.env import get_env_key_or
+
+
+def test_get_env_key_returns_environment_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    monkeypatch.setenv("OPENALGO_API_KEY", "from-env")
+
+    # Act
+    result = get_env_key("OPENALGO_API_KEY")
+
+    # Assert
+    assert result == "from-env"
+
+
+def test_get_env_key_returns_file_value(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # Arrange
+    secret_file = tmp_path / "openalgo.key"
+    secret_file.write_text("from-file\n", encoding="utf-8")
+    monkeypatch.delenv("OPENALGO_API_KEY", raising=False)
+    monkeypatch.setenv("OPENALGO_API_KEY_FILE", str(secret_file))
+
+    # Act
+    result = get_env_key("OPENALGO_API_KEY")
+
+    # Assert
+    assert result == "from-file"
+
+
+def test_get_env_key_returns_dotenv_value(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # Arrange
+    monkeypatch.delenv("OPENALGO_API_KEY", raising=False)
+    monkeypatch.delenv("OPENALGO_API_KEY_FILE", raising=False)
+    dotenv = tmp_path / ".env"
+    dotenv.write_text("OPENALGO_API_KEY=from-dotenv\n", encoding="utf-8")
+    monkeypatch.chdir(tmp_path)
+
+    # Act
+    result = get_env_key("OPENALGO_API_KEY")
+
+    # Assert
+    assert result == "from-dotenv"
+
+
+def test_get_env_key_returns_secrets_dir_value(monkeypatch: pytest.MonkeyPatch, tmp_path) -> None:
+    # Arrange
+    monkeypatch.delenv("OPENALGO_API_KEY", raising=False)
+    monkeypatch.delenv("OPENALGO_API_KEY_FILE", raising=False)
+    monkeypatch.setenv("NAUTILUS_DOTENV_FILE", str(tmp_path / "missing.env"))
+    monkeypatch.setenv("NAUTILUS_SECRETS_DIR", str(tmp_path))
+    (tmp_path / "openalgo_api_key").write_text("from-secret-dir\n", encoding="utf-8")
+
+    # Act
+    result = get_env_key("OPENALGO_API_KEY")
+
+    # Assert
+    assert result == "from-secret-dir"
+
+
+def test_get_env_key_or_returns_default_when_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Arrange
+    monkeypatch.delenv("MISSING_KEY", raising=False)
+
+    # Act
+    result = get_env_key_or("MISSING_KEY", "default-value")
+
+    # Assert
+    assert result == "default-value"


### PR DESCRIPTION
## Summary

Adds an OpenAlgo execution adapter backed by the OpenAlgo Rust SDK, including Python wrapper exports, configuration, factories, and minimal instrument-provider plumbing. This update also adds a Rust integration smoke test that models a tiny strategy placing a market BUY through the OpenAlgo adapter into a local mock OpenAlgo server.

## Testing

- `cargo +1.97.0 test -p nautilus-openalgo -- --nocapture` passed before this commit with the existing SDK payload test and the new simple strategy smoke test.
- `cargo +1.97.0 fmt -p nautilus-openalgo --check` passed, with only the repo existing stable-rustfmt warnings for nightly-only import options.
- Final rerun of `cargo +1.97.0 test -p nautilus-openalgo -- --nocapture` was blocked locally by `No space left on device` while Cargo wrote into `target/debug`.

## PR Target

Base repository and branch: `arif-b-khan/nautilus_trader:main`.

No merge was performed.