### PR TITLE
ci: use PAT for upstream sync pushes

### DIFF
--- a/.github/workflows/sync-upstream-develop.yml
+++ b/.github/workflows/sync-upstream-develop.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           fetch-depth: 0
+          token: ${{ secrets.PAT_TOKEN }}
           persist-credentials: true
 
       - name: Configure Git user
@@ -58,11 +59,12 @@ jobs:
 
       - name: Create or reuse PR from develop to main
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           set -euo pipefail
 
           existing_pr="$(gh pr list \
+            --repo "${{ github.repository }}" \
             --base "${MAIN_BRANCH}" \
             --head "${DEVELOP_BRANCH}" \
             --state open \
@@ -71,6 +73,7 @@ jobs:
 
           if [ -z "${existing_pr}" ]; then
             gh pr create \
+              --repo "${{ github.repository }}" \
               --base "${MAIN_BRANCH}" \
               --head "${DEVELOP_BRANCH}" \
               --title "Sync ${DEVELOP_BRANCH} into ${MAIN_BRANCH}" \


### PR DESCRIPTION
## Root cause\nThe scheduled upstream sync used the default GITHUB_TOKEN for checkout and git push. When the upstream merge included workflow files, GitHub rejected the push because GITHUB_TOKEN lacked workflows permission.\n\n## Fix\n- Use secrets.PAT_TOKEN for checkout so persisted Git credentials can push workflow changes.\n- Use secrets.PAT_TOKEN for gh CLI authentication.\n- Explicitly target the fork repository for PR lookup and creation.\n\nThe PAT must be configured as a repository secret named PAT_TOKEN with access to this fork.