### PR TITLE
Add OpenAlgo brokerage and options support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7459,9 +7459,9 @@ checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openalgo"
-version = "1.0.5"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63f464ef4c8f886e328ca7f3856a47a862473d7f0d978560026b923e67ffa5ef"
+checksum = "532cb94f308c59c63ddd953c455152584cceb548dfb01081488b52de85e192ab"
 dependencies = [
  "futures-util",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ mimalloc = "0.1.52"
 object_store = { version = "0.13.2", default-features = false, features = [
   "fs",
 ] }
-openalgo = "=1.0.5"
+openalgo = "=1.1.0"
 parquet = { version = "58.4.0", default-features = false, features = [
   "arrow",
   "async",

--- a/crates/adapters/openalgo/README.md
+++ b/crates/adapters/openalgo/README.md
@@ -1,3 +1,65 @@
 # Nautilus OpenAlgo Adapter
 
-OpenAlgo integration adapter for NautilusTrader.
+Rust-native OpenAlgo integration for NautilusTrader, built on the official
+`openalgo` crate.
+
+## Relative Options API
+
+`OpenAlgoHttpClient` exposes typed Rust methods for:
+
+- single and multi-leg options orders
+- basket orders using exact contract symbols
+- option chain and expiry discovery
+- option symbol lookup
+- single and multi-option Greeks
+- synthetic futures
+- option quotes and historical data
+- analyzer status
+
+`OpenAlgoOptionsAdapter` accepts an underlying and one to twenty arbitrary
+relative option legs. It is not tied to a named strategy or index.
+
+Relative strikes accept both the user-facing bracket notation and OpenAlgo's
+canonical notation:
+
+- `[atm-0]`, `ATM`, and `ATM0` become `ATM`
+- `[itm-1]`, `ITM-1`, and `ITM1` become `ITM1`
+- `[otm-1]`, `OTM-1`, and `OTM1` become `OTM1`
+
+Calling `preview` resolves the current exact symbols without locking them. A
+later preview may return different symbols as the underlying moves. Calling
+`submit` sends the relative selectors and stores the exact symbols returned by
+OpenAlgo. `close_open_legs` always uses those booked symbols and never
+recalculates ATM, ITM, or OTM.
+
+Multi-leg responses are not atomic. `PartialSuccessPolicy::KeepAccepted`
+retains accepted exact contracts for the caller, while
+`PartialSuccessPolicy::CloseAccepted` immediately attempts to close only the
+accepted symbols. Failed closes remain retryable.
+
+## Analyzer Example
+
+The example reads arbitrary legs from JSON. It previews them first, then refuses
+to submit unless the server confirms analyzer mode and an explicit environment
+confirmation is present.
+
+```bash
+export OPENALGO_API_KEY="..."
+export OPENALGO_HOST="https://your-openalgo-host"
+export OPENALGO_UNDERLYING="NIFTY"
+export OPENALGO_UNDERLYING_EXCHANGE="NSE_INDEX"
+export OPENALGO_OPTIONS_EXCHANGE="NFO"
+export OPENALGO_STRATEGY="RelativeLegs"
+export OPENALGO_OPTION_LEGS='[
+  {"id":"call-hedge","option_type":"CE","strike":"[otm-3]","action":"BUY","quantity":75,"expiry_date":"30JUL26"},
+  {"id":"call-short","option_type":"CE","strike":"[otm-1]","action":"SELL","quantity":75,"expiry_date":"30JUL26"},
+  {"id":"put-short","option_type":"PE","strike":"[otm-1]","action":"SELL","quantity":75,"expiry_date":"30JUL26"},
+  {"id":"put-hedge","option_type":"PE","strike":"[otm-3]","action":"BUY","quantity":75,"expiry_date":"30JUL26"}
+]'
+export OPENALGO_CONFIRM_ANALYZER_ORDER="yes"
+
+cargo run -p nautilus-openalgo --example relative_options_analyzer
+```
+
+The example submits the analyzer order and prints each exact booked contract.
+It does not close the contracts automatically.

--- a/crates/adapters/openalgo/examples/relative_options_analyzer.rs
+++ b/crates/adapters/openalgo/examples/relative_options_analyzer.rs
@@ -1,0 +1,85 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::env;
+
+use anyhow::{Context, Result, ensure};
+use nautilus_openalgo::{
+    OpenAlgoHttpClient, OpenAlgoOptionsAdapter, OptionLegSpec, PartialSuccessPolicy,
+    RelativeOptionsOrder,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let api_key = required_env("OPENALGO_API_KEY")?;
+    let host = required_env("OPENALGO_HOST")?;
+    let legs = serde_json::from_str::<Vec<OptionLegSpec>>(&required_env("OPENALGO_OPTION_LEGS")?)
+        .context("OPENALGO_OPTION_LEGS must be a JSON array of option legs")?;
+    let order = RelativeOptionsOrder {
+        strategy: required_env("OPENALGO_STRATEGY")?,
+        underlying: required_env("OPENALGO_UNDERLYING")?,
+        exchange: required_env("OPENALGO_UNDERLYING_EXCHANGE")?,
+        options_exchange: required_env("OPENALGO_OPTIONS_EXCHANGE")?,
+        legs,
+        partial_success: PartialSuccessPolicy::CloseAccepted,
+    };
+
+    let client = OpenAlgoHttpClient::new(&api_key, &host, "v1", "");
+    let adapter = OpenAlgoOptionsAdapter::new(client.clone());
+    for leg in adapter.preview(&order).await? {
+        println!(
+            "Preview {}: {} {} -> {}.{}",
+            leg.id, leg.option_type, leg.requested_strike, leg.symbol, leg.exchange
+        );
+    }
+
+    let analyzer = client.analyzer_status().await?;
+    ensure!(
+        analyzer
+            .data
+            .as_ref()
+            .and_then(|data| data.analyze_mode)
+            .unwrap_or(false),
+        "OpenAlgo is not in analyzer mode; refusing to submit"
+    );
+    ensure!(
+        env::var("OPENALGO_CONFIRM_ANALYZER_ORDER").as_deref() == Ok("yes"),
+        "set OPENALGO_CONFIRM_ANALYZER_ORDER=yes to submit the analyzer order"
+    );
+
+    let booking = adapter.submit(&order).await?;
+    for leg in &booking.legs {
+        println!(
+            "Booked {}: {} {} -> {}.{}, order {}",
+            leg.id,
+            leg.option_type,
+            leg.requested_strike,
+            leg.symbol,
+            leg.exchange,
+            leg.opening_order_id
+        );
+    }
+    for leg in &booking.rejected {
+        println!("Rejected {}: {}", leg.id, leg.status);
+    }
+    if let Some(error) = booking.recovery_error {
+        anyhow::bail!("partial-submission recovery failed: {error}");
+    }
+    Ok(())
+}
+
+fn required_env(name: &str) -> Result<String> {
+    env::var(name).with_context(|| format!("{name} is required"))
+}

--- a/crates/adapters/openalgo/src/http/client.rs
+++ b/crates/adapters/openalgo/src/http/client.rs
@@ -13,21 +13,31 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
+use std::{collections::HashMap, fmt, sync::Arc};
+
 use anyhow::Result;
-use openalgo::OpenAlgo;
+use openalgo::{
+    AnalyzerStatusResponse, BasketOrderItem, BasketOrderResponse, ExpiryResponse, OpenAlgo,
+    OpenAlgoClient, OptionChainResponse, OptionGreeksResponse, OptionSymbolResponse, OptionsLeg,
+    OptionsMultiOrderResponse, OptionsOrderResponse, OrderResponse, QuotesResponse,
+    SyntheticFutureResponse,
+};
 use serde::Serialize;
-use std::{fmt, sync::Arc};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+use super::models::{
+    MultiOptionGreeksInstrument, MultiOptionGreeksRequest, MultiOptionGreeksResponse,
+};
 
 #[cfg_attr(
     feature = "python",
-    pyo3::pyclass(
-        module = "nautilus_trader._libnautilus.openalgo",
-        from_py_object
-    )
+    pyo3::pyclass(module = "nautilus_trader._libnautilus.openalgo", skip_from_py_object)
 )]
 #[derive(Clone)]
 pub struct OpenAlgoHttpClient {
     inner: Arc<OpenAlgo>,
+    raw: Arc<OpenAlgoClient>,
 }
 
 impl OpenAlgoHttpClient {
@@ -35,9 +45,11 @@ impl OpenAlgoHttpClient {
     pub fn new(api_key: &str, host: &str, version: &str, ws_url: &str) -> Self {
         Self {
             inner: Arc::new(OpenAlgo::with_config(api_key, host, version, ws_url)),
+            raw: Arc::new(OpenAlgoClient::new(api_key, host, version, ws_url)),
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn place_order(
         &self,
         strategy: &str,
@@ -62,6 +74,7 @@ impl OpenAlgoHttpClient {
                         product,
                         quantity,
                         price.unwrap_or("0"),
+                        None,
                     )
                     .await?
             }
@@ -76,13 +89,14 @@ impl OpenAlgoHttpClient {
                         quantity,
                         price.unwrap_or("0"),
                         trigger_price.unwrap_or("0"),
+                        None,
                     )
                     .await?
             }
             _ => {
                 self.inner
                     .place_order(
-                        strategy, symbol, action, exchange, pricetype, product, quantity,
+                        strategy, symbol, action, exchange, pricetype, product, quantity, None,
                     )
                     .await?
             }
@@ -91,6 +105,7 @@ impl OpenAlgoHttpClient {
         to_json(response)
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub async fn modify_order(
         &self,
         orderid: &str,
@@ -107,9 +122,233 @@ impl OpenAlgoHttpClient {
             .inner
             .modify_order(
                 orderid, strategy, symbol, action, exchange, pricetype, product, quantity, price,
+                None, None, None,
             )
             .await?;
         to_json(response)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn place_order_typed(
+        &self,
+        strategy: &str,
+        symbol: &str,
+        action: &str,
+        exchange: &str,
+        pricetype: &str,
+        product: &str,
+        quantity: &str,
+    ) -> Result<OrderResponse> {
+        Ok(self
+            .inner
+            .place_order(
+                strategy, symbol, action, exchange, pricetype, product, quantity, None,
+            )
+            .await?)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn options_order(
+        &self,
+        strategy: &str,
+        underlying: &str,
+        exchange: &str,
+        offset: &str,
+        option_type: &str,
+        action: &str,
+        quantity: &str,
+        pricetype: &str,
+        product: &str,
+        expiry_date: Option<&str>,
+        strike_int: Option<i32>,
+        extra: Option<HashMap<String, Value>>,
+    ) -> Result<OptionsOrderResponse> {
+        Ok(self
+            .inner
+            .options_order(
+                strategy,
+                underlying,
+                exchange,
+                offset,
+                option_type,
+                action,
+                quantity,
+                pricetype,
+                product,
+                expiry_date,
+                strike_int,
+                extra,
+            )
+            .await?)
+    }
+
+    pub async fn options_multi_order(
+        &self,
+        strategy: &str,
+        underlying: &str,
+        exchange: &str,
+        expiry_date: &str,
+        legs: Vec<OptionsLeg>,
+    ) -> Result<OptionsMultiOrderResponse> {
+        Ok(self
+            .inner
+            .options_multi_order(strategy, underlying, exchange, expiry_date, legs)
+            .await?)
+    }
+
+    pub async fn basket_order(
+        &self,
+        strategy: &str,
+        orders: Vec<BasketOrderItem>,
+    ) -> Result<BasketOrderResponse> {
+        Ok(self.inner.basket_order(strategy, orders).await?)
+    }
+
+    pub async fn option_chain(
+        &self,
+        underlying: &str,
+        exchange: &str,
+        expiry_date: &str,
+        strike_count: Option<i32>,
+    ) -> Result<OptionChainResponse> {
+        let response = match strike_count {
+            Some(count) => {
+                self.inner
+                    .data
+                    .option_chain_strikes(underlying, exchange, expiry_date, count)
+                    .await?
+            }
+            None => {
+                self.inner
+                    .option_chain(underlying, exchange, expiry_date)
+                    .await?
+            }
+        };
+        Ok(response)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn option_symbol(
+        &self,
+        underlying: &str,
+        exchange: &str,
+        offset: &str,
+        option_type: &str,
+        expiry_date: Option<&str>,
+        strategy: Option<&str>,
+        strike_int: Option<i32>,
+        extra: Option<HashMap<String, Value>>,
+    ) -> Result<OptionSymbolResponse> {
+        Ok(self
+            .inner
+            .option_symbol(
+                underlying,
+                exchange,
+                offset,
+                option_type,
+                expiry_date,
+                strategy,
+                strike_int,
+                extra,
+            )
+            .await?)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn option_greeks(
+        &self,
+        symbol: &str,
+        exchange: &str,
+        interest_rate: Option<f64>,
+        forward_price: Option<f64>,
+        underlying_symbol: Option<&str>,
+        underlying_exchange: Option<&str>,
+        expiry_time: Option<&str>,
+        extra: Option<HashMap<String, Value>>,
+    ) -> Result<OptionGreeksResponse> {
+        Ok(self
+            .inner
+            .option_greeks(
+                symbol,
+                exchange,
+                interest_rate,
+                forward_price,
+                underlying_symbol,
+                underlying_exchange,
+                expiry_time,
+                extra,
+            )
+            .await?)
+    }
+
+    pub async fn multi_option_greeks(
+        &self,
+        symbols: Vec<MultiOptionGreeksInstrument>,
+        interest_rate: Option<f64>,
+        expiry_time: Option<&str>,
+    ) -> Result<MultiOptionGreeksResponse> {
+        let request = MultiOptionGreeksRequest {
+            apikey: self.raw.api_key.clone(),
+            symbols,
+            interest_rate,
+            expiry_time: expiry_time.map(str::to_string),
+        };
+        Ok(self.raw.post("multioptiongreeks", &request).await?)
+    }
+
+    pub async fn expiry(
+        &self,
+        symbol: &str,
+        exchange: &str,
+        instrument_type: &str,
+    ) -> Result<ExpiryResponse> {
+        Ok(self.inner.expiry(symbol, exchange, instrument_type).await?)
+    }
+
+    pub async fn synthetic_future(
+        &self,
+        underlying: &str,
+        exchange: &str,
+        expiry_date: &str,
+    ) -> Result<SyntheticFutureResponse> {
+        Ok(self
+            .inner
+            .synthetic_future(underlying, exchange, expiry_date)
+            .await?)
+    }
+
+    pub async fn quotes(&self, symbol: &str, exchange: &str) -> Result<QuotesResponse> {
+        Ok(self.inner.quotes(symbol, exchange).await?)
+    }
+
+    pub async fn history_range(
+        &self,
+        symbol: &str,
+        exchange: &str,
+        interval: &str,
+        start_date: &str,
+        end_date: &str,
+    ) -> Result<Value> {
+        Ok(self
+            .inner
+            .history_range(symbol, exchange, interval, start_date, end_date)
+            .await?)
+    }
+
+    pub async fn analyzer_status(&self) -> Result<AnalyzerStatusResponse> {
+        Ok(self.inner.analyzer_status().await?)
+    }
+
+    pub(crate) fn api_key(&self) -> String {
+        self.raw.api_key.clone()
+    }
+
+    pub(crate) async fn post<T, R>(&self, endpoint: &str, request: &T) -> Result<R>
+    where
+        T: Serialize,
+        R: DeserializeOwned,
+    {
+        Ok(self.raw.post(endpoint, request).await?)
     }
 
     pub async fn cancel_order(&self, orderid: &str, strategy: &str) -> Result<String> {

--- a/crates/adapters/openalgo/src/http/models.rs
+++ b/crates/adapters/openalgo/src/http/models.rs
@@ -1,0 +1,75 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use openalgo::OptionGreeksResponse;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize)]
+pub struct MultiOptionGreeksInstrument {
+    pub symbol: String,
+    pub exchange: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlying_symbol: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub underlying_exchange: Option<String>,
+}
+
+impl MultiOptionGreeksInstrument {
+    #[must_use]
+    pub fn new(symbol: impl Into<String>, exchange: impl Into<String>) -> Self {
+        Self {
+            symbol: symbol.into(),
+            exchange: exchange.into(),
+            underlying_symbol: None,
+            underlying_exchange: None,
+        }
+    }
+
+    #[must_use]
+    pub fn with_underlying(
+        mut self,
+        symbol: impl Into<String>,
+        exchange: impl Into<String>,
+    ) -> Self {
+        self.underlying_symbol = Some(symbol.into());
+        self.underlying_exchange = Some(exchange.into());
+        self
+    }
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct MultiOptionGreeksRequest {
+    pub apikey: String,
+    pub symbols: Vec<MultiOptionGreeksInstrument>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub interest_rate: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expiry_time: Option<String>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize, Eq, PartialEq)]
+pub struct MultiOptionGreeksSummary {
+    pub total: usize,
+    pub success: usize,
+    pub failed: usize,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct MultiOptionGreeksResponse {
+    pub status: String,
+    pub data: Option<Vec<OptionGreeksResponse>>,
+    pub summary: Option<MultiOptionGreeksSummary>,
+    pub message: Option<String>,
+}

--- a/crates/adapters/openalgo/src/lib.rs
+++ b/crates/adapters/openalgo/src/lib.rs
@@ -23,8 +23,27 @@
 #![deny(rustdoc::broken_intra_doc_links)]
 
 pub mod http;
+pub mod options;
 
 #[cfg(feature = "python")]
 pub mod python;
 
 pub use crate::http::client::OpenAlgoHttpClient;
+pub use crate::{
+    http::models::{
+        MultiOptionGreeksInstrument, MultiOptionGreeksResponse, MultiOptionGreeksSummary,
+    },
+    options::{
+        execution::OpenAlgoOptionsAdapter,
+        models::{
+            BookedLegState, BookedOptionLeg, OptionAction, OptionLegSpec, OptionPriceType,
+            OptionProduct, OptionType, OptionsBooking, OptionsCloseOutcome, PartialSuccessPolicy,
+            RejectedOptionLeg, RelativeOptionsOrder, RelativeStrike, ResolvedOptionLeg,
+        },
+    },
+};
+pub use openalgo::{
+    BasketOrderItem, BasketOrderResponse, ExpiryResponse, OptionChainResponse,
+    OptionGreeksResponse, OptionSymbolResponse, OptionsLeg, OptionsMultiOrderResponse,
+    OptionsOrderResponse, QuotesResponse, SyntheticFutureResponse,
+};

--- a/crates/adapters/openalgo/src/options/execution.rs
+++ b/crates/adapters/openalgo/src/options/execution.rs
@@ -1,0 +1,318 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::collections::HashSet;
+
+use anyhow::{Context, Result, bail, ensure};
+use openalgo::BasketOrderItem;
+
+use super::models::{
+    BookedLegState, BookedOptionLeg, OptionsBooking, OptionsCloseOutcome, OptionsMultiOrderRequest,
+    OptionsMultiOrderResponse, PartialSuccessPolicy, RejectedOptionLeg, RelativeOptionsOrder,
+    ResolvedOptionLeg, normalize_expiry,
+};
+use crate::OpenAlgoHttpClient;
+
+/// Generic adapter-level relative-options selection and execution.
+#[derive(Clone, Debug)]
+pub struct OpenAlgoOptionsAdapter {
+    client: OpenAlgoHttpClient,
+}
+
+impl OpenAlgoOptionsAdapter {
+    #[must_use]
+    pub const fn new(client: OpenAlgoHttpClient) -> Self {
+        Self { client }
+    }
+
+    /// Resolves the latest exact symbol for every relative leg without placing orders.
+    ///
+    /// Calling this method again may return different symbols when the underlying ATM
+    /// strike moves. A preview does not lock a contract.
+    pub async fn preview(&self, order: &RelativeOptionsOrder) -> Result<Vec<ResolvedOptionLeg>> {
+        order.validate()?;
+        let mut resolved = Vec::with_capacity(order.legs.len());
+
+        for leg in &order.legs {
+            let expiry = normalize_expiry(&leg.expiry_date);
+            let response = self
+                .client
+                .option_symbol(
+                    &order.underlying,
+                    &order.exchange,
+                    &leg.strike.to_string(),
+                    &leg.option_type.to_string(),
+                    Some(&expiry),
+                    Some(&order.strategy),
+                    None,
+                    None,
+                )
+                .await
+                .with_context(|| format!("resolving option leg {}", leg.id))?;
+            ensure!(
+                is_success(&response.status),
+                "leg {} resolution failed: {}",
+                leg.id,
+                response
+                    .message
+                    .as_deref()
+                    .unwrap_or("OpenAlgo returned an error")
+            );
+            let symbol = response
+                .symbol
+                .context(format!("leg {} resolution omitted symbol", leg.id))?;
+            let exchange = response
+                .exchange
+                .unwrap_or_else(|| order.options_exchange.clone());
+            let lot_size = response
+                .lotsize
+                .context(format!("leg {} resolution omitted lot size", leg.id))?;
+            ensure!(
+                leg.quantity % lot_size == 0,
+                "leg {} quantity {} is not a multiple of lot size {}",
+                leg.id,
+                leg.quantity,
+                lot_size
+            );
+
+            resolved.push(ResolvedOptionLeg {
+                id: leg.id.clone(),
+                requested_strike: leg.strike,
+                option_type: leg.option_type,
+                expiry_date: expiry,
+                symbol,
+                exchange,
+                lot_size,
+                tick_size: response.tick_size,
+                freeze_quantity: response.freeze_qty,
+                underlying_ltp: response.underlying_ltp,
+            });
+        }
+        Ok(resolved)
+    }
+
+    /// Submits one to twenty arbitrary relative option legs.
+    ///
+    /// Exact symbols returned for accepted legs are retained in the booking. Relative
+    /// selectors are never used to close a booked leg.
+    pub async fn submit(&self, order: &RelativeOptionsOrder) -> Result<OptionsBooking> {
+        order.validate()?;
+        let request = OptionsMultiOrderRequest {
+            apikey: self.client.api_key(),
+            strategy: order.strategy.clone(),
+            underlying: order.underlying.clone(),
+            exchange: order.exchange.clone(),
+            legs: order.legs.iter().map(Into::into).collect(),
+        };
+        let response: OptionsMultiOrderResponse = self
+            .client
+            .post("optionsmultiorder", &request)
+            .await
+            .context("submitting relative option legs")?;
+        let mut booking = self.parse_booking(order, response)?;
+
+        if !booking.rejected.is_empty()
+            && !booking.legs.is_empty()
+            && order.partial_success == PartialSuccessPolicy::CloseAccepted
+        {
+            match self.close_open_legs(&mut booking).await {
+                Ok(outcome) if !outcome.rejected.is_empty() => {
+                    booking.recovery_error = Some(format!(
+                        "automatic close rejected legs: {}",
+                        outcome.rejected.join(", ")
+                    ));
+                }
+                Err(error) => booking.recovery_error = Some(error.to_string()),
+                _ => {}
+            }
+        }
+        Ok(booking)
+    }
+
+    /// Closes every still-open booked leg using its exact resolved symbol.
+    ///
+    /// Successfully closed legs are not included in later retries.
+    pub async fn close_open_legs(
+        &self,
+        booking: &mut OptionsBooking,
+    ) -> Result<OptionsCloseOutcome> {
+        let open = booking
+            .legs
+            .iter()
+            .enumerate()
+            .filter(|(_, leg)| !matches!(leg.state, BookedLegState::Closed { .. }))
+            .map(|(index, leg)| {
+                (
+                    index,
+                    BasketOrderItem::new(
+                        &leg.symbol,
+                        &leg.exchange,
+                        &leg.opening_action.opposite().to_string(),
+                        leg.quantity,
+                        "MARKET",
+                        &leg.product.to_string(),
+                    ),
+                )
+            })
+            .collect::<Vec<_>>();
+        if open.is_empty() {
+            return Ok(OptionsCloseOutcome::default());
+        }
+
+        let response = self
+            .client
+            .basket_order(
+                &booking.strategy,
+                open.iter().map(|(_, order)| order.clone()).collect(),
+            )
+            .await
+            .context("closing exact booked option legs")?;
+        let results = response.results.unwrap_or_default();
+        let mut outcome = OptionsCloseOutcome::default();
+
+        for (index, _) in open {
+            let leg = &mut booking.legs[index];
+            match results.iter().find(|result| result.symbol == leg.symbol) {
+                Some(result) if is_success(&result.status) => {
+                    let order_id = result
+                        .orderid
+                        .clone()
+                        .context("successful close response omitted order ID")?;
+                    leg.state = BookedLegState::Closed { order_id };
+                    outcome.closed.push(leg.id.clone());
+                }
+                _ => {
+                    leg.state = BookedLegState::CloseRejected;
+                    outcome.rejected.push(leg.id.clone());
+                }
+            }
+        }
+        Ok(outcome)
+    }
+
+    fn parse_booking(
+        &self,
+        order: &RelativeOptionsOrder,
+        response: OptionsMultiOrderResponse,
+    ) -> Result<OptionsBooking> {
+        let results = response.results.unwrap_or_default();
+        let mut seen = HashSet::new();
+        let mut booked = Vec::new();
+        let mut rejected = Vec::new();
+
+        for result in results {
+            ensure!(
+                result.leg > 0 && (result.leg as usize) <= order.legs.len(),
+                "OpenAlgo returned invalid leg number {}",
+                result.leg
+            );
+            ensure!(
+                seen.insert(result.leg),
+                "OpenAlgo returned duplicate leg number {}",
+                result.leg
+            );
+            let spec = &order.legs[result.leg as usize - 1];
+            validate_echoed_leg(spec, &result)?;
+
+            if is_success(&result.status) {
+                booked.push(BookedOptionLeg {
+                    id: spec.id.clone(),
+                    requested_strike: spec.strike,
+                    option_type: spec.option_type,
+                    opening_action: spec.action,
+                    quantity: spec.quantity,
+                    product: spec.product,
+                    expiry_date: normalize_expiry(&spec.expiry_date),
+                    symbol: result
+                        .symbol
+                        .context(format!("accepted leg {} omitted symbol", spec.id))?,
+                    exchange: result
+                        .exchange
+                        .unwrap_or_else(|| order.options_exchange.clone()),
+                    opening_order_id: result
+                        .orderid
+                        .context(format!("accepted leg {} omitted order ID", spec.id))?,
+                    state: BookedLegState::Open,
+                });
+            } else {
+                rejected.push(RejectedOptionLeg {
+                    id: spec.id.clone(),
+                    status: result.status,
+                    message: result.message,
+                });
+            }
+        }
+
+        for (index, spec) in order.legs.iter().enumerate() {
+            if !seen.contains(&((index + 1) as i32)) {
+                rejected.push(RejectedOptionLeg {
+                    id: spec.id.clone(),
+                    status: response.status.clone(),
+                    message: response.message.clone(),
+                });
+            }
+        }
+        if booked.is_empty() && rejected.is_empty() {
+            bail!(
+                "OpenAlgo returned no leg results: {}",
+                response.message.as_deref().unwrap_or("unknown error")
+            );
+        }
+
+        Ok(OptionsBooking {
+            strategy: order.strategy.clone(),
+            underlying: response
+                .underlying
+                .unwrap_or_else(|| order.underlying.clone()),
+            underlying_ltp: response.underlying_ltp,
+            mode: response.mode,
+            legs: booked,
+            rejected,
+            recovery_error: None,
+        })
+    }
+}
+
+fn validate_echoed_leg(
+    spec: &super::models::OptionLegSpec,
+    result: &super::models::OptionsMultiOrderResult,
+) -> Result<()> {
+    if let Some(offset) = result.offset.as_deref() {
+        ensure!(
+            offset.eq_ignore_ascii_case(&spec.strike.to_string()),
+            "OpenAlgo returned unexpected offset {offset} for leg {}",
+            spec.id
+        );
+    }
+    if let Some(option_type) = result.option_type.as_deref() {
+        ensure!(
+            option_type.eq_ignore_ascii_case(&spec.option_type.to_string()),
+            "OpenAlgo returned unexpected option type {option_type} for leg {}",
+            spec.id
+        );
+    }
+    if let Some(action) = result.action.as_deref() {
+        ensure!(
+            action.eq_ignore_ascii_case(&spec.action.to_string()),
+            "OpenAlgo returned unexpected action {action} for leg {}",
+            spec.id
+        );
+    }
+    Ok(())
+}
+
+fn is_success(status: &str) -> bool {
+    status.eq_ignore_ascii_case("success")
+}

--- a/crates/adapters/openalgo/src/options/mod.rs
+++ b/crates/adapters/openalgo/src/options/mod.rs
@@ -13,5 +13,7 @@
 //  limitations under the License.
 // -------------------------------------------------------------------------------------------------
 
-pub mod client;
+//! Generic relative-options selection and execution for OpenAlgo.
+
+pub mod execution;
 pub mod models;

--- a/crates/adapters/openalgo/src/options/models.rs
+++ b/crates/adapters/openalgo/src/options/models.rs
@@ -1,0 +1,503 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::{fmt, str::FromStr};
+
+use anyhow::{Result, bail, ensure};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, de::Error};
+
+/// A strike selected relative to the moving at-the-money strike.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum RelativeStrike {
+    Atm,
+    Itm(u8),
+    Otm(u8),
+}
+
+impl RelativeStrike {
+    fn validate_level(kind: &str, level: u8) -> Result<u8> {
+        ensure!(
+            (1..=50).contains(&level),
+            "{kind} level must be between 1 and 50"
+        );
+        Ok(level)
+    }
+}
+
+impl fmt::Display for RelativeStrike {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Atm => f.write_str("ATM"),
+            Self::Itm(level) => write!(f, "ITM{level}"),
+            Self::Otm(level) => write!(f, "OTM{level}"),
+        }
+    }
+}
+
+impl FromStr for RelativeStrike {
+    type Err = anyhow::Error;
+
+    fn from_str(value: &str) -> Result<Self> {
+        let normalized = value
+            .trim()
+            .trim_start_matches('[')
+            .trim_end_matches(']')
+            .to_ascii_uppercase();
+        if normalized == "ATM" || normalized == "ATM-0" || normalized == "ATM0" {
+            return Ok(Self::Atm);
+        }
+
+        let parse_level = |prefix: &str| -> Result<u8> {
+            let raw = normalized
+                .strip_prefix(prefix)
+                .ok_or_else(|| anyhow::anyhow!("invalid relative strike: {value}"))?
+                .strip_prefix('-')
+                .unwrap_or_else(|| normalized.strip_prefix(prefix).unwrap_or_default());
+            let level = raw
+                .parse::<u8>()
+                .map_err(|_| anyhow::anyhow!("invalid relative strike: {value}"))?;
+            Self::validate_level(prefix, level)
+        };
+
+        if normalized.starts_with("ITM") {
+            return Ok(Self::Itm(parse_level("ITM")?));
+        }
+        if normalized.starts_with("OTM") {
+            return Ok(Self::Otm(parse_level("OTM")?));
+        }
+        bail!("invalid relative strike: {value}")
+    }
+}
+
+impl Serialize for RelativeStrike {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for RelativeStrike {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        String::deserialize(deserializer)?
+            .parse()
+            .map_err(D::Error::custom)
+    }
+}
+
+/// Option contract kind.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum OptionType {
+    Ce,
+    Pe,
+}
+
+impl fmt::Display for OptionType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Ce => "CE",
+            Self::Pe => "PE",
+        })
+    }
+}
+
+/// Opening action for an option leg.
+#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum OptionAction {
+    Buy,
+    Sell,
+}
+
+impl OptionAction {
+    #[must_use]
+    pub const fn opposite(self) -> Self {
+        match self {
+            Self::Buy => Self::Sell,
+            Self::Sell => Self::Buy,
+        }
+    }
+}
+
+impl fmt::Display for OptionAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Buy => "BUY",
+            Self::Sell => "SELL",
+        })
+    }
+}
+
+/// OpenAlgo option order price type.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+pub enum OptionPriceType {
+    #[default]
+    #[serde(rename = "MARKET")]
+    Market,
+    #[serde(rename = "LIMIT")]
+    Limit,
+    #[serde(rename = "SL")]
+    StopLimit,
+    #[serde(rename = "SL-M")]
+    StopMarket,
+}
+
+/// OpenAlgo option product.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, Hash, PartialEq, Serialize)]
+#[serde(rename_all = "UPPERCASE")]
+pub enum OptionProduct {
+    #[default]
+    Mis,
+    Nrml,
+}
+
+impl fmt::Display for OptionProduct {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Mis => "MIS",
+            Self::Nrml => "NRML",
+        })
+    }
+}
+
+/// Behavior when OpenAlgo accepts only part of a multi-leg submission.
+#[derive(Clone, Copy, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PartialSuccessPolicy {
+    #[default]
+    KeepAccepted,
+    CloseAccepted,
+}
+
+/// User-defined relative option leg.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct OptionLegSpec {
+    pub id: String,
+    pub option_type: OptionType,
+    pub strike: RelativeStrike,
+    pub action: OptionAction,
+    pub quantity: i32,
+    pub expiry_date: String,
+    #[serde(default)]
+    pub splitsize: i32,
+    #[serde(default)]
+    pub pricetype: OptionPriceType,
+    #[serde(default)]
+    pub product: OptionProduct,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+    #[serde(default)]
+    pub disclosed_quantity: i32,
+}
+
+impl OptionLegSpec {
+    #[must_use]
+    pub fn market(
+        id: impl Into<String>,
+        option_type: OptionType,
+        strike: RelativeStrike,
+        action: OptionAction,
+        quantity: i32,
+        expiry_date: impl Into<String>,
+    ) -> Self {
+        Self {
+            id: id.into(),
+            option_type,
+            strike,
+            action,
+            quantity,
+            expiry_date: normalize_expiry(&expiry_date.into()),
+            splitsize: 0,
+            pricetype: OptionPriceType::Market,
+            product: OptionProduct::Mis,
+            price: None,
+            trigger_price: None,
+            disclosed_quantity: 0,
+        }
+    }
+
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(!self.id.trim().is_empty(), "leg id cannot be empty");
+        ensure!(
+            self.quantity > 0,
+            "leg {} quantity must be positive",
+            self.id
+        );
+        ensure!(
+            !self.expiry_date.trim().is_empty(),
+            "leg {} expiry_date cannot be empty",
+            self.id
+        );
+        ensure!(
+            self.splitsize >= 0,
+            "leg {} splitsize cannot be negative",
+            self.id
+        );
+        ensure!(
+            self.disclosed_quantity >= 0,
+            "leg {} disclosed_quantity cannot be negative",
+            self.id
+        );
+        if self.pricetype == OptionPriceType::Limit {
+            ensure!(
+                self.price.is_some_and(|price| price > 0.0),
+                "leg {} LIMIT order requires a positive price",
+                self.id
+            );
+        }
+        if matches!(
+            self.pricetype,
+            OptionPriceType::StopLimit | OptionPriceType::StopMarket
+        ) {
+            ensure!(
+                self.trigger_price.is_some_and(|price| price > 0.0),
+                "leg {} stop order requires a positive trigger_price",
+                self.id
+            );
+        }
+        Ok(())
+    }
+}
+
+/// A generic relative-options submission for one underlying.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct RelativeOptionsOrder {
+    pub strategy: String,
+    pub underlying: String,
+    pub exchange: String,
+    pub options_exchange: String,
+    pub legs: Vec<OptionLegSpec>,
+    #[serde(default)]
+    pub partial_success: PartialSuccessPolicy,
+}
+
+impl RelativeOptionsOrder {
+    pub(crate) fn validate(&self) -> Result<()> {
+        ensure!(!self.strategy.trim().is_empty(), "strategy cannot be empty");
+        ensure!(
+            !self.underlying.trim().is_empty(),
+            "underlying cannot be empty"
+        );
+        ensure!(!self.exchange.trim().is_empty(), "exchange cannot be empty");
+        ensure!(
+            !self.options_exchange.trim().is_empty(),
+            "options_exchange cannot be empty"
+        );
+        ensure!(
+            (1..=20).contains(&self.legs.len()),
+            "options order must contain 1 to 20 legs"
+        );
+        for leg in &self.legs {
+            leg.validate()?;
+        }
+        for (index, leg) in self.legs.iter().enumerate() {
+            ensure!(
+                !self.legs[..index]
+                    .iter()
+                    .any(|previous| previous.id == leg.id),
+                "duplicate leg id: {}",
+                leg.id
+            );
+        }
+        Ok(())
+    }
+}
+
+/// Exact contract selected during a non-trading preview.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedOptionLeg {
+    pub id: String,
+    pub requested_strike: RelativeStrike,
+    pub option_type: OptionType,
+    pub expiry_date: String,
+    pub symbol: String,
+    pub exchange: String,
+    pub lot_size: i32,
+    pub tick_size: Option<f64>,
+    pub freeze_quantity: Option<i32>,
+    pub underlying_ltp: Option<f64>,
+}
+
+/// State of an exact contract accepted by OpenAlgo.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum BookedLegState {
+    Open,
+    Closed { order_id: String },
+    CloseRejected,
+}
+
+/// Exact contract identity returned by OpenAlgo after submission.
+#[derive(Clone, Debug, PartialEq)]
+pub struct BookedOptionLeg {
+    pub id: String,
+    pub requested_strike: RelativeStrike,
+    pub option_type: OptionType,
+    pub opening_action: OptionAction,
+    pub quantity: i32,
+    pub product: OptionProduct,
+    pub expiry_date: String,
+    pub symbol: String,
+    pub exchange: String,
+    pub opening_order_id: String,
+    pub state: BookedLegState,
+}
+
+/// A leg rejected during a multi-leg submission.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct RejectedOptionLeg {
+    pub id: String,
+    pub status: String,
+    pub message: Option<String>,
+}
+
+/// Result of submitting arbitrary relative option legs.
+#[derive(Clone, Debug, PartialEq)]
+pub struct OptionsBooking {
+    pub strategy: String,
+    pub underlying: String,
+    pub underlying_ltp: Option<f64>,
+    pub mode: Option<String>,
+    pub legs: Vec<BookedOptionLeg>,
+    pub rejected: Vec<RejectedOptionLeg>,
+    pub recovery_error: Option<String>,
+}
+
+impl OptionsBooking {
+    #[must_use]
+    pub fn is_complete(&self) -> bool {
+        self.rejected.is_empty()
+    }
+
+    #[must_use]
+    pub fn has_open_legs(&self) -> bool {
+        self.legs
+            .iter()
+            .any(|leg| !matches!(leg.state, BookedLegState::Closed { .. }))
+    }
+}
+
+/// Exact-symbol close result.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct OptionsCloseOutcome {
+    pub closed: Vec<String>,
+    pub rejected: Vec<String>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OptionsMultiOrderRequest {
+    pub apikey: String,
+    pub strategy: String,
+    pub underlying: String,
+    pub exchange: String,
+    pub legs: Vec<OptionsMultiOrderLegRequest>,
+}
+
+#[derive(Clone, Debug, Serialize)]
+pub(crate) struct OptionsMultiOrderLegRequest {
+    pub offset: String,
+    pub option_type: String,
+    pub action: String,
+    pub quantity: i32,
+    pub expiry_date: String,
+    pub splitsize: i32,
+    pub pricetype: OptionPriceType,
+    pub product: OptionProduct,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub price: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub trigger_price: Option<f64>,
+    pub disclosed_quantity: i32,
+}
+
+impl From<&OptionLegSpec> for OptionsMultiOrderLegRequest {
+    fn from(value: &OptionLegSpec) -> Self {
+        Self {
+            offset: value.strike.to_string(),
+            option_type: value.option_type.to_string(),
+            action: value.action.to_string(),
+            quantity: value.quantity,
+            expiry_date: normalize_expiry(&value.expiry_date),
+            splitsize: value.splitsize,
+            pricetype: value.pricetype,
+            product: value.product,
+            price: value.price,
+            trigger_price: value.trigger_price,
+            disclosed_quantity: value.disclosed_quantity,
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct OptionsMultiOrderResponse {
+    pub status: String,
+    pub underlying: Option<String>,
+    pub underlying_ltp: Option<f64>,
+    pub mode: Option<String>,
+    pub results: Option<Vec<OptionsMultiOrderResult>>,
+    pub message: Option<String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub(crate) struct OptionsMultiOrderResult {
+    pub leg: i32,
+    pub symbol: Option<String>,
+    pub exchange: Option<String>,
+    pub offset: Option<String>,
+    pub option_type: Option<String>,
+    pub action: Option<String>,
+    pub status: String,
+    pub orderid: Option<String>,
+    pub message: Option<String>,
+}
+
+pub(crate) fn normalize_expiry(value: &str) -> String {
+    value.trim().replace('-', "").to_ascii_uppercase()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_bracket_and_openalgo_relative_strikes() {
+        assert_eq!(
+            "[atm-0]".parse::<RelativeStrike>().unwrap(),
+            RelativeStrike::Atm
+        );
+        assert_eq!(
+            "OTM-3".parse::<RelativeStrike>().unwrap(),
+            RelativeStrike::Otm(3)
+        );
+        assert_eq!(
+            "itm2".parse::<RelativeStrike>().unwrap(),
+            RelativeStrike::Itm(2)
+        );
+        assert_eq!(RelativeStrike::Otm(3).to_string(), "OTM3");
+    }
+
+    #[test]
+    fn rejects_invalid_relative_strike_levels() {
+        assert!("OTM0".parse::<RelativeStrike>().is_err());
+        assert!("ITM51".parse::<RelativeStrike>().is_err());
+        assert!("ATM-1".parse::<RelativeStrike>().is_err());
+    }
+}

--- a/crates/adapters/openalgo/tests/options_adapter.rs
+++ b/crates/adapters/openalgo/tests/options_adapter.rs
@@ -1,0 +1,439 @@
+// -------------------------------------------------------------------------------------------------
+//  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+//  https://nautechsystems.io
+//
+//  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+//  You may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+// -------------------------------------------------------------------------------------------------
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use axum::{Json, Router, extract::State, routing::post};
+use nautilus_openalgo::{
+    BookedLegState, OpenAlgoHttpClient, OpenAlgoOptionsAdapter, OptionAction, OptionLegSpec,
+    OptionType, PartialSuccessPolicy, RelativeOptionsOrder, RelativeStrike,
+};
+use serde_json::{Value, json};
+use tokio::{net::TcpListener, sync::Mutex};
+
+#[derive(Clone, Debug, Default)]
+struct MockState {
+    requests: Arc<Mutex<Vec<(String, Value)>>>,
+    option_symbol_calls: Arc<AtomicUsize>,
+    basket_calls: Arc<AtomicUsize>,
+    partial_submission: bool,
+    partial_close: bool,
+}
+
+#[tokio::test]
+async fn arbitrary_legs_use_canonical_offsets_and_lock_exact_symbols() {
+    let (adapter, state) = mock_adapter(false, false).await;
+    let order = iron_condor_order(PartialSuccessPolicy::KeepAccepted);
+
+    let first_preview = adapter.preview(&single_leg_order()).await.unwrap();
+    let second_preview = adapter.preview(&single_leg_order()).await.unwrap();
+    assert_ne!(first_preview[0].symbol, second_preview[0].symbol);
+
+    let mut booking = adapter.submit(&order).await.unwrap();
+    assert!(booking.is_complete());
+    assert_eq!(booking.legs.len(), 4);
+    assert_eq!(booking.legs[0].symbol, "NIFTY30JUL2625300CE");
+    assert_eq!(booking.legs[3].symbol, "NIFTY30JUL2624700PE");
+
+    let outcome = adapter.close_open_legs(&mut booking).await.unwrap();
+    assert_eq!(outcome.closed.len(), 4);
+    assert!(!booking.has_open_legs());
+
+    let requests = state.requests.lock().await;
+    assert_request(
+        &requests,
+        "optionsmultiorder",
+        json!({
+            "apikey": "KEY",
+            "strategy": "RelativeLegs",
+            "underlying": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "legs": [
+                {
+                    "offset": "OTM3",
+                    "option_type": "CE",
+                    "action": "BUY",
+                    "quantity": 75,
+                    "expiry_date": "30JUL26",
+                    "splitsize": 0,
+                    "pricetype": "MARKET",
+                    "product": "MIS",
+                    "disclosed_quantity": 0
+                },
+                {
+                    "offset": "OTM1",
+                    "option_type": "CE",
+                    "action": "SELL",
+                    "quantity": 75,
+                    "expiry_date": "30JUL26",
+                    "splitsize": 0,
+                    "pricetype": "MARKET",
+                    "product": "MIS",
+                    "disclosed_quantity": 0
+                },
+                {
+                    "offset": "OTM1",
+                    "option_type": "PE",
+                    "action": "SELL",
+                    "quantity": 75,
+                    "expiry_date": "30JUL26",
+                    "splitsize": 0,
+                    "pricetype": "MARKET",
+                    "product": "MIS",
+                    "disclosed_quantity": 0
+                },
+                {
+                    "offset": "OTM3",
+                    "option_type": "PE",
+                    "action": "BUY",
+                    "quantity": 75,
+                    "expiry_date": "30JUL26",
+                    "splitsize": 0,
+                    "pricetype": "MARKET",
+                    "product": "MIS",
+                    "disclosed_quantity": 0
+                }
+            ]
+        }),
+    );
+    assert_request(
+        &requests,
+        "basketorder",
+        json!({
+            "apikey": "KEY",
+            "strategy": "RelativeLegs",
+            "orders": [
+                {
+                    "symbol": "NIFTY30JUL2625300CE",
+                    "exchange": "NFO",
+                    "action": "SELL",
+                    "quantity": 75,
+                    "pricetype": "MARKET",
+                    "product": "MIS"
+                },
+                {
+                    "symbol": "NIFTY30JUL2625100CE",
+                    "exchange": "NFO",
+                    "action": "BUY",
+                    "quantity": 75,
+                    "pricetype": "MARKET",
+                    "product": "MIS"
+                },
+                {
+                    "symbol": "NIFTY30JUL2624900PE",
+                    "exchange": "NFO",
+                    "action": "BUY",
+                    "quantity": 75,
+                    "pricetype": "MARKET",
+                    "product": "MIS"
+                },
+                {
+                    "symbol": "NIFTY30JUL2624700PE",
+                    "exchange": "NFO",
+                    "action": "SELL",
+                    "quantity": 75,
+                    "pricetype": "MARKET",
+                    "product": "MIS"
+                }
+            ]
+        }),
+    );
+}
+
+#[tokio::test]
+async fn partial_submission_can_close_only_the_accepted_exact_leg() {
+    let (adapter, state) = mock_adapter(true, false).await;
+    let order = RelativeOptionsOrder {
+        partial_success: PartialSuccessPolicy::CloseAccepted,
+        ..single_leg_pair_order()
+    };
+
+    let booking = adapter.submit(&order).await.unwrap();
+    assert!(!booking.is_complete());
+    assert_eq!(booking.rejected[0].id, "put");
+    assert!(matches!(
+        booking.legs[0].state,
+        BookedLegState::Closed { .. }
+    ));
+    assert!(booking.recovery_error.is_none());
+
+    let requests = state.requests.lock().await;
+    let basket = requests
+        .iter()
+        .find(|(endpoint, _)| endpoint == "basketorder")
+        .map(|(_, payload)| payload)
+        .unwrap();
+    assert_eq!(basket["orders"].as_array().unwrap().len(), 1);
+    assert_eq!(basket["orders"][0]["symbol"], "NIFTY30JUL2625000CE");
+}
+
+#[tokio::test]
+async fn close_retry_excludes_already_closed_exact_legs() {
+    let (adapter, state) = mock_adapter(false, true).await;
+    let mut booking = adapter
+        .submit(&iron_condor_order(PartialSuccessPolicy::KeepAccepted))
+        .await
+        .unwrap();
+
+    let first = adapter.close_open_legs(&mut booking).await.unwrap();
+    assert_eq!(first.closed.len(), 3);
+    assert_eq!(first.rejected, vec!["short-call"]);
+    assert!(booking.has_open_legs());
+
+    let second = adapter.close_open_legs(&mut booking).await.unwrap();
+    assert_eq!(second.closed, vec!["short-call"]);
+    assert!(!booking.has_open_legs());
+
+    let requests = state.requests.lock().await;
+    let baskets = requests
+        .iter()
+        .filter(|(endpoint, _)| endpoint == "basketorder")
+        .map(|(_, payload)| payload)
+        .collect::<Vec<_>>();
+    assert_eq!(baskets.len(), 2);
+    assert_eq!(baskets[0]["orders"].as_array().unwrap().len(), 4);
+    assert_eq!(baskets[1]["orders"].as_array().unwrap().len(), 1);
+    assert_eq!(baskets[1]["orders"][0]["symbol"], "NIFTY30JUL2625100CE");
+}
+
+fn iron_condor_order(partial_success: PartialSuccessPolicy) -> RelativeOptionsOrder {
+    RelativeOptionsOrder {
+        strategy: "RelativeLegs".to_string(),
+        underlying: "NIFTY".to_string(),
+        exchange: "NSE_INDEX".to_string(),
+        options_exchange: "NFO".to_string(),
+        legs: vec![
+            leg(
+                "long-call",
+                OptionType::Ce,
+                RelativeStrike::Otm(3),
+                OptionAction::Buy,
+            ),
+            leg(
+                "short-call",
+                OptionType::Ce,
+                RelativeStrike::Otm(1),
+                OptionAction::Sell,
+            ),
+            leg(
+                "short-put",
+                OptionType::Pe,
+                RelativeStrike::Otm(1),
+                OptionAction::Sell,
+            ),
+            leg(
+                "long-put",
+                OptionType::Pe,
+                RelativeStrike::Otm(3),
+                OptionAction::Buy,
+            ),
+        ],
+        partial_success,
+    }
+}
+
+fn single_leg_order() -> RelativeOptionsOrder {
+    RelativeOptionsOrder {
+        strategy: "Preview".to_string(),
+        underlying: "NIFTY".to_string(),
+        exchange: "NSE_INDEX".to_string(),
+        options_exchange: "NFO".to_string(),
+        legs: vec![leg(
+            "moving",
+            OptionType::Ce,
+            RelativeStrike::Itm(1),
+            OptionAction::Buy,
+        )],
+        partial_success: PartialSuccessPolicy::KeepAccepted,
+    }
+}
+
+fn single_leg_pair_order() -> RelativeOptionsOrder {
+    RelativeOptionsOrder {
+        strategy: "RelativeLegs".to_string(),
+        underlying: "NIFTY".to_string(),
+        exchange: "NSE_INDEX".to_string(),
+        options_exchange: "NFO".to_string(),
+        legs: vec![
+            leg(
+                "call",
+                OptionType::Ce,
+                RelativeStrike::Atm,
+                OptionAction::Buy,
+            ),
+            leg(
+                "put",
+                OptionType::Pe,
+                RelativeStrike::Atm,
+                OptionAction::Buy,
+            ),
+        ],
+        partial_success: PartialSuccessPolicy::KeepAccepted,
+    }
+}
+
+fn leg(
+    id: &str,
+    option_type: OptionType,
+    strike: RelativeStrike,
+    action: OptionAction,
+) -> OptionLegSpec {
+    OptionLegSpec::market(id, option_type, strike, action, 75, "30-Jul-26")
+}
+
+async fn mock_adapter(
+    partial_submission: bool,
+    partial_close: bool,
+) -> (OpenAlgoOptionsAdapter, MockState) {
+    let state = MockState {
+        partial_submission,
+        partial_close,
+        ..MockState::default()
+    };
+    let app = Router::new()
+        .route("/api/v1/optionsymbol", post(option_symbol))
+        .route("/api/v1/optionsmultiorder", post(options_multi_order))
+        .route("/api/v1/basketorder", post(basket_order))
+        .with_state(state.clone());
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let host = format!("http://{}", listener.local_addr().unwrap());
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.unwrap();
+    });
+    let client = OpenAlgoHttpClient::new("KEY", &host, "v1", "ws://127.0.0.1");
+    (OpenAlgoOptionsAdapter::new(client), state)
+}
+
+async fn option_symbol(State(state): State<MockState>, Json(payload): Json<Value>) -> Json<Value> {
+    capture(&state, "optionsymbol", payload).await;
+    let call = state.option_symbol_calls.fetch_add(1, Ordering::SeqCst);
+    let strike = if call == 0 { 24_900 } else { 25_000 };
+    Json(json!({
+        "status": "success",
+        "symbol": format!("NIFTY30JUL26{strike}CE"),
+        "exchange": "NFO",
+        "lotsize": 75,
+        "tick_size": 0.05,
+        "freeze_qty": 1800,
+        "underlying_ltp": if call == 0 { 25010.0 } else { 25110.0 }
+    }))
+}
+
+async fn options_multi_order(
+    State(state): State<MockState>,
+    Json(payload): Json<Value>,
+) -> Json<Value> {
+    capture(&state, "optionsmultiorder", payload).await;
+    if state.partial_submission {
+        return Json(json!({
+            "status": "partial",
+            "underlying": "NIFTY",
+            "underlying_ltp": 25010.0,
+            "mode": "analyze",
+            "results": [
+                {
+                    "leg": 1,
+                    "symbol": "NIFTY30JUL2625000CE",
+                    "exchange": "NFO",
+                    "offset": "ATM",
+                    "option_type": "CE",
+                    "action": "BUY",
+                    "status": "success",
+                    "orderid": "SB-CALL"
+                },
+                {
+                    "leg": 2,
+                    "offset": "ATM",
+                    "option_type": "PE",
+                    "action": "BUY",
+                    "status": "error",
+                    "message": "insufficient funds"
+                }
+            ]
+        }));
+    }
+
+    Json(json!({
+        "status": "success",
+        "underlying": "NIFTY",
+        "underlying_ltp": 25010.0,
+        "mode": "analyze",
+        "results": [
+            result(1, "NIFTY30JUL2625300CE", "OTM3", "CE", "BUY"),
+            result(2, "NIFTY30JUL2625100CE", "OTM1", "CE", "SELL"),
+            result(3, "NIFTY30JUL2624900PE", "OTM1", "PE", "SELL"),
+            result(4, "NIFTY30JUL2624700PE", "OTM3", "PE", "BUY")
+        ]
+    }))
+}
+
+fn result(leg: i32, symbol: &str, offset: &str, option_type: &str, action: &str) -> Value {
+    json!({
+        "leg": leg,
+        "symbol": symbol,
+        "exchange": "NFO",
+        "offset": offset,
+        "option_type": option_type,
+        "action": action,
+        "status": "success",
+        "orderid": format!("SB-{leg}")
+    })
+}
+
+async fn basket_order(State(state): State<MockState>, Json(payload): Json<Value>) -> Json<Value> {
+    capture(&state, "basketorder", payload.clone()).await;
+    let call = state.basket_calls.fetch_add(1, Ordering::SeqCst);
+    let results = payload["orders"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .enumerate()
+        .map(|(index, order)| {
+            let rejected = state.partial_close && call == 0 && index == 1;
+            json!({
+                "symbol": order["symbol"],
+                "status": if rejected { "error" } else { "success" },
+                "orderid": if rejected {
+                    Value::Null
+                } else {
+                    json!(format!("SB-CLOSE-{}", index + 1))
+                }
+            })
+        })
+        .collect::<Vec<_>>();
+    Json(json!({"status": "success", "results": results}))
+}
+
+async fn capture(state: &MockState, endpoint: &str, payload: Value) {
+    state
+        .requests
+        .lock()
+        .await
+        .push((endpoint.to_string(), payload));
+}
+
+fn assert_request(requests: &[(String, Value)], endpoint: &str, expected: Value) {
+    let actual = requests
+        .iter()
+        .find(|(name, _)| name == endpoint)
+        .map_or_else(
+            || panic!("missing {endpoint} request"),
+            |(_, payload)| payload,
+        );
+    assert_eq!(actual, &expected);
+}

--- a/examples/backtest/openalgo_nifty_long_straddle.py
+++ b/examples/backtest/openalgo_nifty_long_straddle.py
@@ -1,0 +1,330 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+"""
+Self-contained NIFTY long-straddle backtest using OpenAlgo relative strike selectors.
+
+The strategy resolves both ``[atm-0]`` legs from Nautilus option instruments at
+entry time. It then retains and exits those exact contracts after NIFTY moves to
+a new ATM strike. No OpenAlgo network request or API key is used in backtesting.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC
+from datetime import datetime
+from datetime import timedelta
+
+from nautilus_trader.adapters.openalgo.options import resolve_openalgo_option
+from nautilus_trader.backtest.engine import BacktestEngine
+from nautilus_trader.backtest.engine import BacktestEngineConfig
+from nautilus_trader.config import LoggingConfig
+from nautilus_trader.config import StrategyConfig
+from nautilus_trader.core.datetime import dt_to_unix_nanos
+from nautilus_trader.model.data import QuoteTick
+from nautilus_trader.model.enums import AccountType
+from nautilus_trader.model.enums import AssetClass
+from nautilus_trader.model.enums import OmsType
+from nautilus_trader.model.enums import OptionKind
+from nautilus_trader.model.enums import OrderSide
+from nautilus_trader.model.enums import PriceType
+from nautilus_trader.model.identifiers import InstrumentId
+from nautilus_trader.model.identifiers import Symbol
+from nautilus_trader.model.identifiers import Venue
+from nautilus_trader.model.instruments import IndexInstrument
+from nautilus_trader.model.instruments import OptionContract
+from nautilus_trader.model.objects import Currency
+from nautilus_trader.model.objects import Money
+from nautilus_trader.model.objects import Price
+from nautilus_trader.model.objects import Quantity
+from nautilus_trader.trading.strategy import Strategy
+
+
+NSE_INDEX = Venue("NSE_INDEX")
+NFO = Venue("NFO")
+INR = Currency.from_str("INR")
+NIFTY_ID = InstrumentId.from_str("NIFTY.NSE_INDEX")
+START = datetime(2026, 7, 30, 3, 45, tzinfo=UTC)  # 09:15 Asia/Kolkata
+EXPIRY = datetime(2026, 8, 6, 10, 0, tzinfo=UTC)
+EXPIRY_NS = dt_to_unix_nanos(EXPIRY)
+STRIKES = (24_900, 25_000, 25_100)
+
+
+class OpenAlgoLongStraddleConfig(StrategyConfig, frozen=True):
+    underlying_id: InstrumentId
+    option_venue: Venue
+    expiration_ns: int
+    call_strike: str = "[atm-0]"
+    put_strike: str = "[atm-0]"
+    quantity: int = 75
+    exit_after_underlying_quotes: int = 5
+
+
+class OpenAlgoLongStraddleBacktest(Strategy):
+    """
+    Resolves moving OpenAlgo selectors once and trades the resulting exact contracts.
+    """
+
+    def __init__(self, config: OpenAlgoLongStraddleConfig) -> None:
+        super().__init__(config=config)
+        self.call_id: InstrumentId | None = None
+        self.put_id: InstrumentId | None = None
+        self._latest_underlying = 0.0
+        self._selected_quotes: set[InstrumentId] = set()
+        self._entry_submitted = False
+        self._entry_fills = 0
+        self._exit_submitted = False
+        self._underlying_quotes = 0
+
+    def on_start(self) -> None:
+        self.subscribe_quote_ticks(self.config.underlying_id)
+        for instrument in self.cache.instruments(
+            venue=self.config.option_venue,
+            underlying="NIFTY",
+        ):
+            self.subscribe_quote_ticks(instrument.id)
+
+    def on_stop(self) -> None:
+        self.unsubscribe_quote_ticks(self.config.underlying_id)
+        for instrument in self.cache.instruments(
+            venue=self.config.option_venue,
+            underlying="NIFTY",
+        ):
+            self.unsubscribe_quote_ticks(instrument.id)
+
+    def on_quote_tick(self, tick: QuoteTick) -> None:
+        if tick.instrument_id == self.config.underlying_id:
+            self._underlying_quotes += 1
+            self._latest_underlying = tick.extract_price(PriceType.MID).as_double()
+            if self.call_id is None:
+                self._resolve_and_lock_contracts()
+            if (
+                self._entry_fills == 2
+                and not self._exit_submitted
+                and self._underlying_quotes >= self.config.exit_after_underlying_quotes
+            ):
+                self._submit_exit()
+            return
+
+        if tick.instrument_id in {self.call_id, self.put_id}:
+            self._selected_quotes.add(tick.instrument_id)
+            if (
+                not self._entry_submitted
+                and self.call_id in self._selected_quotes
+                and self.put_id in self._selected_quotes
+            ):
+                self._submit_entry()
+
+    def on_order_filled(self, event) -> None:
+        if not self._exit_submitted:
+            self._entry_fills += 1
+        self.log.warning(
+            f"Fill {event.instrument_id}: {event.order_side} {event.last_qty} @ {event.last_px}",
+        )
+
+    def _resolve_and_lock_contracts(self) -> None:
+        instruments = self.cache.instruments(
+            venue=self.config.option_venue,
+            underlying="NIFTY",
+        )
+        call = resolve_openalgo_option(
+            instruments,
+            underlying_price=self._latest_underlying,
+            option_kind=OptionKind.CALL,
+            strike_selector=self.config.call_strike,
+            expiration_ns=self.config.expiration_ns,
+        )
+        put = resolve_openalgo_option(
+            instruments,
+            underlying_price=self._latest_underlying,
+            option_kind=OptionKind.PUT,
+            strike_selector=self.config.put_strike,
+            expiration_ns=self.config.expiration_ns,
+        )
+        self.call_id = call.id
+        self.put_id = put.id
+        self.log.warning(
+            f"Locked selectors at NIFTY={self._latest_underlying:.2f}: "
+            f"{self.call_id}, {self.put_id}",
+        )
+
+    def _submit_entry(self) -> None:
+        assert self.call_id is not None
+        assert self.put_id is not None
+        self._entry_submitted = True
+        for instrument_id in (self.call_id, self.put_id):
+            order = self.order_factory.market(
+                instrument_id=instrument_id,
+                order_side=OrderSide.BUY,
+                quantity=Quantity.from_int(self.config.quantity),
+            )
+            self.submit_order(order)
+
+    def _submit_exit(self) -> None:
+        assert self.call_id is not None
+        assert self.put_id is not None
+        self._exit_submitted = True
+        self.log.warning(
+            f"NIFTY moved to {self._latest_underlying:.2f}; closing locked "
+            f"contracts {self.call_id}, {self.put_id}",
+        )
+        for instrument_id in (self.call_id, self.put_id):
+            order = self.order_factory.market(
+                instrument_id=instrument_id,
+                order_side=OrderSide.SELL,
+                quantity=Quantity.from_int(self.config.quantity),
+            )
+            self.submit_order(order)
+
+
+def create_nifty_index() -> IndexInstrument:
+    return IndexInstrument(
+        instrument_id=NIFTY_ID,
+        raw_symbol=Symbol("NIFTY"),
+        currency=INR,
+        price_precision=2,
+        size_precision=0,
+        price_increment=Price.from_str("0.05"),
+        size_increment=Quantity.from_int(1),
+        ts_event=0,
+        ts_init=0,
+    )
+
+
+def create_option(strike: int, kind: OptionKind) -> OptionContract:
+    suffix = "CE" if kind is OptionKind.CALL else "PE"
+    symbol = f"NIFTY06AUG26{strike}{suffix}"
+    return OptionContract(
+        instrument_id=InstrumentId.from_str(f"{symbol}.NFO"),
+        raw_symbol=Symbol(symbol),
+        asset_class=AssetClass.INDEX,
+        underlying="NIFTY",
+        option_kind=kind,
+        strike_price=Price.from_str(f"{strike}.00"),
+        currency=INR,
+        activation_ns=dt_to_unix_nanos(START - timedelta(days=30)),
+        expiration_ns=EXPIRY_NS,
+        price_precision=2,
+        price_increment=Price.from_str("0.05"),
+        multiplier=Quantity.from_int(1),
+        lot_size=Quantity.from_int(75),
+        ts_event=0,
+        ts_init=0,
+        exchange="NFO",
+    )
+
+
+def quote(
+    instrument_id: InstrumentId,
+    bid: float,
+    ask: float,
+    timestamp_ns: int,
+    size: int = 1_800,
+) -> QuoteTick:
+    return QuoteTick(
+        instrument_id=instrument_id,
+        bid_price=Price.from_str(f"{bid:.2f}"),
+        ask_price=Price.from_str(f"{ask:.2f}"),
+        bid_size=Quantity.from_int(size),
+        ask_size=Quantity.from_int(size),
+        ts_event=timestamp_ns,
+        ts_init=timestamp_ns,
+    )
+
+
+def create_data(options: list[OptionContract]) -> list[QuoteTick]:
+    underlying_prices = (25_020.0, 25_040.0, 25_080.0, 25_120.0, 25_140.0, 25_160.0)
+    data: list[QuoteTick] = []
+
+    for minute, underlying in enumerate(underlying_prices):
+        timestamp = dt_to_unix_nanos(START + timedelta(minutes=minute))
+        data.append(quote(NIFTY_ID, underlying - 0.5, underlying + 0.5, timestamp, size=1))
+
+        for offset, instrument in enumerate(options, start=1):
+            strike = instrument.strike_price.as_double()
+            intrinsic = (
+                max(underlying - strike, 0.0)
+                if instrument.option_kind is OptionKind.CALL
+                else max(strike - underlying, 0.0)
+            )
+            time_value = max(35.0, 105.0 - (minute * 8.0) - abs(strike - underlying) * 0.15)
+            mid = intrinsic + time_value
+            data.append(
+                quote(
+                    instrument.id,
+                    mid - 0.5,
+                    mid + 0.5,
+                    timestamp + offset,
+                ),
+            )
+    return data
+
+
+def run_backtest() -> None:
+    engine = BacktestEngine(
+        config=BacktestEngineConfig(
+            trader_id="OPENALGO-BACKTEST-001",
+            logging=LoggingConfig(log_level="WARNING"),
+        ),
+    )
+    engine.add_venue(
+        venue=NSE_INDEX,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.CASH,
+        base_currency=INR,
+        starting_balances=[Money(1_000_000, INR)],
+    )
+    engine.add_venue(
+        venue=NFO,
+        oms_type=OmsType.NETTING,
+        account_type=AccountType.MARGIN,
+        base_currency=INR,
+        starting_balances=[Money(1_000_000, INR)],
+    )
+
+    index = create_nifty_index()
+    options = [
+        create_option(strike, kind)
+        for strike in STRIKES
+        for kind in (OptionKind.CALL, OptionKind.PUT)
+    ]
+    engine.add_instrument(index)
+    for option in options:
+        engine.add_instrument(option)
+    engine.add_data(create_data(options))
+
+    strategy = OpenAlgoLongStraddleBacktest(
+        config=OpenAlgoLongStraddleConfig(
+            underlying_id=index.id,
+            option_venue=NFO,
+            expiration_ns=EXPIRY_NS,
+        ),
+    )
+    engine.add_strategy(strategy)
+    engine.run()
+
+    assert strategy.call_id == InstrumentId.from_str("NIFTY06AUG2625000CE.NFO")
+    assert strategy.put_id == InstrumentId.from_str("NIFTY06AUG2625000PE.NFO")
+    assert len(engine.cache.orders_closed(venue=NFO)) == 4
+    assert not engine.cache.positions_open(venue=NFO)
+
+    print(engine.trader.generate_order_fills_report())
+    print(engine.trader.generate_positions_report())
+    print(engine.trader.generate_account_report(NFO))
+    engine.dispose()
+
+
+if __name__ == "__main__":
+    run_backtest()

--- a/nautilus_trader/adapters/openalgo/__init__.py
+++ b/nautilus_trader/adapters/openalgo/__init__.py
@@ -18,6 +18,9 @@ from nautilus_trader.adapters.openalgo.execution import OpenAlgoExecutionClient
 from nautilus_trader.adapters.openalgo.factories import OpenAlgoLiveExecClientFactory
 from nautilus_trader.adapters.openalgo.factories import get_cached_openalgo_http_client
 from nautilus_trader.adapters.openalgo.factories import get_cached_openalgo_instrument_provider
+from nautilus_trader.adapters.openalgo.options import OpenAlgoRelativeStrike
+from nautilus_trader.adapters.openalgo.options import RelativeStrikeKind
+from nautilus_trader.adapters.openalgo.options import resolve_openalgo_option
 from nautilus_trader.adapters.openalgo.providers import OpenAlgoInstrumentProvider
 
 
@@ -26,6 +29,9 @@ __all__ = [
     "OpenAlgoExecutionClient",
     "OpenAlgoInstrumentProvider",
     "OpenAlgoLiveExecClientFactory",
+    "OpenAlgoRelativeStrike",
+    "RelativeStrikeKind",
     "get_cached_openalgo_http_client",
     "get_cached_openalgo_instrument_provider",
+    "resolve_openalgo_option",
 ]

--- a/nautilus_trader/adapters/openalgo/options.py
+++ b/nautilus_trader/adapters/openalgo/options.py
@@ -1,0 +1,129 @@
+# -------------------------------------------------------------------------------------------------
+#  Copyright (C) 2015-2026 Nautech Systems Pty Ltd. All rights reserved.
+#  https://nautechsystems.io
+#
+#  Licensed under the GNU Lesser General Public License Version 3.0 (the "License");
+#  You may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at https://www.gnu.org/licenses/lgpl-3.0.en.html
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+# -------------------------------------------------------------------------------------------------
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import Enum
+
+from nautilus_trader.model.enums import OptionKind
+from nautilus_trader.model.instruments import OptionContract
+
+
+class RelativeStrikeKind(Enum):
+    """
+    Relative option strike category.
+    """
+
+    ATM = "ATM"
+    ITM = "ITM"
+    OTM = "OTM"
+
+
+@dataclass(frozen=True)
+class OpenAlgoRelativeStrike:
+    """
+    Parsed OpenAlgo-style relative strike selector.
+    """
+
+    kind: RelativeStrikeKind
+    level: int = 0
+
+    @classmethod
+    def parse(cls, value: str) -> OpenAlgoRelativeStrike:
+        normalized = value.strip()
+        if normalized.startswith("[") and normalized.endswith("]"):
+            normalized = normalized[1:-1]
+        normalized = normalized.upper()
+
+        if normalized in {"ATM", "ATM0", "ATM-0"}:
+            return cls(RelativeStrikeKind.ATM)
+
+        for name, kind in (
+            ("ITM", RelativeStrikeKind.ITM),
+            ("OTM", RelativeStrikeKind.OTM),
+        ):
+            if normalized.startswith(name):
+                raw_level = normalized[len(name) :].removeprefix("-")
+                try:
+                    level = int(raw_level)
+                except ValueError as exc:
+                    raise ValueError(f"Invalid relative strike selector: {value}") from exc
+                if not 1 <= level <= 50:
+                    raise ValueError(f"{name} level must be between 1 and 50")
+                return cls(kind, level)
+
+        raise ValueError(f"Invalid relative strike selector: {value}")
+
+    @property
+    def canonical(self) -> str:
+        if self.kind is RelativeStrikeKind.ATM:
+            return "ATM"
+        return f"{self.kind.value}{self.level}"
+
+
+def resolve_openalgo_option(
+    instruments: Iterable[OptionContract],
+    *,
+    underlying_price: float,
+    option_kind: OptionKind,
+    strike_selector: str | OpenAlgoRelativeStrike,
+    expiration_ns: int,
+) -> OptionContract:
+    """
+    Resolve an OpenAlgo-style relative strike to an exact Nautilus option contract.
+
+    This helper performs no I/O and is suitable for deterministic backtesting.
+    Calling it again may return a different contract as ``underlying_price`` moves.
+    The caller must retain the returned instrument ID after submitting an order.
+    """
+    selector = (
+        OpenAlgoRelativeStrike.parse(strike_selector)
+        if isinstance(strike_selector, str)
+        else strike_selector
+    )
+    candidates = [
+        instrument
+        for instrument in instruments
+        if isinstance(instrument, OptionContract)
+        and instrument.option_kind == option_kind
+        and instrument.expiration_ns == expiration_ns
+    ]
+    if not candidates:
+        raise ValueError(
+            f"No {option_kind.name} option contracts found for expiration {expiration_ns}",
+        )
+
+    by_strike = {instrument.strike_price.as_double(): instrument for instrument in candidates}
+    strikes = sorted(by_strike)
+    atm_index = min(
+        range(len(strikes)),
+        key=lambda index: (abs(strikes[index] - underlying_price), strikes[index]),
+    )
+
+    direction = 0
+    if selector.kind is RelativeStrikeKind.OTM:
+        direction = 1 if option_kind is OptionKind.CALL else -1
+    elif selector.kind is RelativeStrikeKind.ITM:
+        direction = -1 if option_kind is OptionKind.CALL else 1
+
+    target_index = atm_index + (direction * selector.level)
+    if not 0 <= target_index < len(strikes):
+        raise ValueError(
+            f"{selector.canonical} is unavailable for {option_kind.name} at "
+            f"underlying price {underlying_price}",
+        )
+    return by_strike[strikes[target_index]]


### PR DESCRIPTION
## Summary

- extend the existing Rust OpenAlgo adapter using the official `openalgo` crate
- support configurable multi-leg relative option selectors such as `[atm-0]`, `[itm-1]`, and `[otm-1]`
- lock resolved option symbols after order submission so moving ATM/ITM/OTM references do not change booked legs
- support partial leg submission, exact-symbol closes, and retry-safe close behavior
- expose deterministic relative strike resolution to Python
- add a self-contained NIFTY long-straddle backtest example using the OpenAlgo selector semantics

## Why

This keeps option-leg selection at the adapter level. Strategies can describe legs relative to an underlying at entry time and subsequently manage the exact contracts that were booked.

The backtest example demonstrates that `[atm-0]` resolves both NIFTY legs once, retains those contracts as the underlying moves, and closes the original symbols.

## Validation

- `cargo test -p nautilus-openalgo` (7 passed, including the existing simple strategy smoke test)
- `cargo fmt --all -- --check`
- Ruff check and format verification for the new Python files
- local debug build and NIFTY long-straddle backtest
  - 4 orders filled
  - exact `25000CE` and `25000PE` legs closed after NIFTY moved
  - no open NFO positions
